### PR TITLE
Fix for Noteskin items on OptionList

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/_OptionsList/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/_OptionsList/default.lua
@@ -71,13 +71,7 @@ for i=1,#fixedChar do
 end
 for i=1,#fixedNS do
     local CurrentSkin = fixedNS[i];
-    _NSKIN[i] = Def.ActorFrame{
-        OnCommand=function(s)
-            highlightedNoteSkin = CurrentSkin;
-            s:RemoveAllChildren()
-            s:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/_OptionsList/Noteskin.lua"))
-        end
-    };
+    _NSKIN[i] = LoadModule("NoteskinObjLoad.lua",CurrentSkin)
 end;
 for i=1,#NumMini do
     local CurrentMini = NumMini[i];

--- a/Modules/NoteskinObjLoad.lua
+++ b/Modules/NoteskinObjLoad.lua
@@ -4,7 +4,6 @@ local curgame = GAMESTATE:GetCurrentGame():GetName()
 local GameDirections = { ["dance"] = "Down", ["pump"] = "UpLeft" }
 
 local nbox
-
 if NoteskinToUse ~= "EXIT" then
 	nbox = NOTESKIN:LoadActorForNoteSkin( GameDirections[curgame] , "Tap Note", NoteskinToUse or "default" )
 else
@@ -15,10 +14,9 @@ else
 end
 
 local AFTContainer = Def.ActorFrameTexture{
+	Name="IMG",
 	InitCommand=function(self)
-		self:SetTextureName("NSKIN"..NoteskinToUse):SetWidth(200):SetHeight(200)
-		:EnableAlphaBuffer(true)
-		:Create()
+		self:SetWidth(200):SetHeight(200):EnableAlphaBuffer(true):Create()
 	end,
 	Def.ActorFrame{
 		InitCommand=function(self) self:xy(100,100):zoom(1.5) end,
@@ -27,12 +25,9 @@ local AFTContainer = Def.ActorFrameTexture{
 	}
 }
 
-local t = Def.ActorFrame{
+return Def.ActorFrame{
 	AFTContainer,
-	Def.Sprite{
-		-- 
-		Texture="NSKIN"..NoteskinToUse
-	}
+	Def.Sprite{InitCommand=function(self)
+		self:SetTexture( self:GetParent():GetChild("IMG"):GetTexture() )
+	end}
 }
-
-return t

--- a/Modules/NoteskinObjLoad.lua
+++ b/Modules/NoteskinObjLoad.lua
@@ -1,0 +1,38 @@
+local NoteskinToUse = ...
+local curgame = GAMESTATE:GetCurrentGame():GetName()
+
+local GameDirections = { ["dance"] = "Down", ["pump"] = "UpLeft" }
+
+local nbox
+
+if NoteskinToUse ~= "EXIT" then
+	nbox = NOTESKIN:LoadActorForNoteSkin( GameDirections[curgame] , "Tap Note", NoteskinToUse or "default" )
+else
+	nbox = Def.BitmapText{
+		Font="_avenirnext lt pro bold 20px",
+		Text="EXIT"
+	}
+end
+
+local AFTContainer = Def.ActorFrameTexture{
+	InitCommand=function(self)
+		self:SetTextureName("NSKIN"..NoteskinToUse):SetWidth(200):SetHeight(200)
+		:EnableAlphaBuffer(true)
+		:Create()
+	end,
+	Def.ActorFrame{
+		InitCommand=function(self) self:xy(100,100):zoom(1.5) end,
+		Def.Sprite{ Texture=THEME:GetPathB("ScreenSelectMusic","overlay/_OptionsList/optionIcon") },
+		nbox
+	}
+}
+
+local t = Def.ActorFrame{
+	AFTContainer,
+	Def.Sprite{
+		-- 
+		Texture="NSKIN"..NoteskinToUse
+	}
+}
+
+return t


### PR DESCRIPTION
This fixes the situation with 3D NoteSkins not appearing on MidflightDigital/XX--STARLiGHT--twopointzero#3.
However, this needs more look into, as enabling a second player will begin to draw duplicate texture names, which AFT do not like, and will report back to console and Lua about.