### PR TITLE
Subtracted Score Tracker

### DIFF
--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -120,7 +120,6 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 	};
 end
 
-
 for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
   t[#t+1] = Def.ActorFrame{
     InitCommand=function(s) s:y(_screen.cy-346):draworder(-1)
@@ -173,11 +172,13 @@ for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
         local compare = currentscore - topscore;--compares your performance to your high score
         if (topscore > 0) then --if you have a high score
           if(compare>0) then --if you want to only see the deduction instead of comparing to your high score, change the variable compare to rpm
-          self:settext(compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
-          else
+          self:settext("+" .. compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
+          elseif(compare==0) then --if you are tied with your high score
+          self:settext("+" .. compare):diffuse(color("#ffffff")):strokecolor(Color.Black)--white, you can change this            
+          else --if you are doing worse than your high score
           self:settext(compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
           end;
-        else--if you don't have a high score, this will only show the deduction
+        else --if you don't have a high score, this will only show the deduction
           self:settext(rpm):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
         end;
       end;

--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -1,8 +1,42 @@
 local t = Def.ActorFrame{};
+local jk = LoadModule "Jacket.lua"
 
 t[#t+1] = StatsEngine()
 
 local LoadingScreen = Var "LoadingScreen"
+
+t[#t+1] = loadfile(THEME:GetPathB("","_StageDoors"))()..{
+  InitCommand=function(s)
+    s:visible(true)
+  end,
+  OnCommand=function(s)
+    s:queuecommand("AnOff"):sleep(0.25):queuecommand("Finish")
+  end,
+  FinishCommand=function(s) s:finishtweening():visible(false) end,
+};
+--Jacket--
+t[#t+1] = Def.ActorFrame {
+  InitCommand=function(s)
+    s:Center():diffusealpha(1):zoom(1)
+  end,
+  OnCommand=function(s) s:sleep(0.5):decelerate(0.2):zoom(2):diffusealpha(0) end,
+  Def.Quad{
+    InitCommand=function(s) s:diffuse(Color.Black)
+      s:setsize(628,628)  
+    end,
+  };
+  Def.Sprite {
+    InitCommand=function(self)
+      if GAMESTATE:IsCourseMode() then
+        local ent = GAMESTATE:GetCurrentTrail(GAMESTATE:GetMasterPlayerNumber()):GetTrailEntries()
+        self:Load(jk.GetSongGraphicPath(ent[1]:GetSong()))
+      else
+        self:Load(jk.GetSongGraphicPath(GAMESTATE:GetCurrentSong()))
+      end
+      self:scaletofit(-310,-310,310,310)
+    end;
+  };
+};
 
 t[#t+1] = Def.Actor{
     AfterStatsEngineMessageCommand = function(_,params)
@@ -87,8 +121,8 @@ t[#t+1] = Def.ActorFrame{
         end
       end,
       OnCommand=function(s)
-				s:diffuseshift():effectcolor1(color("1,1,1,1")):effectcolor2(color("1,1,1,0.75")):effectclock('beatnooffset')
-			end
+        s:diffuseshift():effectcolor1(color("1,1,1,1")):effectcolor2(color("1,1,1,0.75")):effectclock('beatnooffset')
+      end
     };
     Def.Sprite{
         Name="StageFrame",
@@ -106,19 +140,20 @@ if not GAMESTATE:IsDemonstration() then
 t[#t+1] = StandardDecorationFromFile("StageDisplay","StageDisplay")
 end
 for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
-	t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/lifeframe"))(pn);
+  t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/lifeframe"))(pn);
 --options--
-	t[#t+1] = loadfile(THEME:GetPathB("","_optionicon"))(pn) .. {
-		InitCommand=function(s) s:player(pn):zoomx(1.8):zoomy(1.8):x(pn==PLAYER_1 and SCREEN_LEFT+200 or SCREEN_RIGHT-200):draworder(1) end,
-		OnCommand=function(self)
-			if GAMESTATE:PlayerIsUsingModifier(pn,'reverse') then
-				self:y(IsUsingWideScreen() and SCREEN_TOP+172 or SCREEN_TOP+142);
-			else
-				self:y(IsUsingWideScreen() and SCREEN_BOTTOM-145 or SCREEN_BOTTOM-130);
-			end;
-		end;
-	};
+  t[#t+1] = loadfile(THEME:GetPathB("","_optionicon"))(pn) .. {
+    InitCommand=function(s) s:player(pn):zoomx(1.8):zoomy(1.8):x(pn==PLAYER_1 and SCREEN_LEFT+200 or SCREEN_RIGHT-200):draworder(1) end,
+    OnCommand=function(self)
+      if GAMESTATE:GetPlayerState(pn):GetPlayerOptions('ModsLevel_Current'):Reverse() == 1 then
+        self:y(IsUsingWideScreen() and SCREEN_TOP+172 or SCREEN_TOP+142);
+      else
+        self:y(IsUsingWideScreen() and SCREEN_BOTTOM-145 or SCREEN_BOTTOM-130);
+      end;
+    end;
+  };
 end
+
 
 for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
   t[#t+1] = Def.ActorFrame{
@@ -172,19 +207,18 @@ for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
         local compare = currentscore - topscore;--compares your performance to your high score
         if (topscore > 0) then --if you have a high score
           if(compare>0) then --if you want to only see the deduction instead of comparing to your high score, change the variable compare to rpm
-          self:settext("+" .. compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
-          elseif(compare==0) then --if you are tied with your high score
-          self:settext("+" .. compare):diffuse(color("#ffffff")):strokecolor(Color.Black)--white, you can change this            
-          else --if you are doing worse than your high score
-          self:settext(compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
+          self:settext('+'):settext(compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
+          else
+          self:settext('+'):settext(compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
           end;
-        else --if you don't have a high score, this will only show the deduction
+        else--if you don't have a high score, this will only show the deduction
           self:settext(rpm):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
         end;
       end;
     };
   };
 end;
+
 
 t[#t+1] = StandardDecorationFromFileOptional("Help","Help");
 t[#t+1] = Def.Sound{

--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -1,42 +1,8 @@
 local t = Def.ActorFrame{};
-local jk = LoadModule "Jacket.lua"
 
 t[#t+1] = StatsEngine()
 
 local LoadingScreen = Var "LoadingScreen"
-
-t[#t+1] = loadfile(THEME:GetPathB("","_StageDoors"))()..{
-  InitCommand=function(s)
-    s:visible(true)
-  end,
-  OnCommand=function(s)
-    s:queuecommand("AnOff"):sleep(0.25):queuecommand("Finish")
-  end,
-  FinishCommand=function(s) s:finishtweening():visible(false) end,
-};
---Jacket--
-t[#t+1] = Def.ActorFrame {
-  InitCommand=function(s)
-    s:Center():diffusealpha(1):zoom(1)
-  end,
-  OnCommand=function(s) s:sleep(0.5):decelerate(0.2):zoom(2):diffusealpha(0) end,
-  Def.Quad{
-    InitCommand=function(s) s:diffuse(Color.Black)
-      s:setsize(628,628)	
-    end,
-  };
-  Def.Sprite {
-    InitCommand=function(self)
-      if GAMESTATE:IsCourseMode() then
-        local ent = GAMESTATE:GetCurrentTrail(GAMESTATE:GetMasterPlayerNumber()):GetTrailEntries()
-        self:Load(jk.GetSongGraphicPath(ent[1]:GetSong()))
-      else
-        self:Load(jk.GetSongGraphicPath(GAMESTATE:GetCurrentSong()))
-      end
-      self:scaletofit(-310,-310,310,310)
-    end;
-  };
-};
 
 t[#t+1] = Def.Actor{
     AfterStatsEngineMessageCommand = function(_,params)
@@ -145,7 +111,7 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 	t[#t+1] = loadfile(THEME:GetPathB("","_optionicon"))(pn) .. {
 		InitCommand=function(s) s:player(pn):zoomx(1.8):zoomy(1.8):x(pn==PLAYER_1 and SCREEN_LEFT+200 or SCREEN_RIGHT-200):draworder(1) end,
 		OnCommand=function(self)
-			if GAMESTATE:GetPlayerState(pn):GetPlayerOptions('ModsLevel_Current'):Reverse() == 1 then
+			if GAMESTATE:PlayerIsUsingModifier(pn,'reverse') then
 				self:y(IsUsingWideScreen() and SCREEN_TOP+172 or SCREEN_TOP+142);
 			else
 				self:y(IsUsingWideScreen() and SCREEN_BOTTOM-145 or SCREEN_BOTTOM-130);
@@ -153,6 +119,71 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 		end;
 	};
 end
+
+
+for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
+  t[#t+1] = Def.ActorFrame{
+    InitCommand=function(s) s:y(_screen.cy-346):draworder(-1)
+      if IsUsingWideScreen() then
+        s:x(pn==PLAYER_1 and _screen.cx-494 or _screen.cx+494)
+      else
+        s:x(pn==PLAYER_1 and _screen.cx-320 or _screen.cx+320)
+      end
+    end,
+    OnCommand=function(s) s:zoom(0):sleep(0.3):bounceend(0.2):zoom(1) end,
+    OffCommand=function(s) s:linear(0.2):zoom(0) end,
+    Def.BitmapText{
+      Font="_russell square 24px";
+      JudgmentMessageCommand=function(self)
+        self:y(256)
+        local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn);
+        local steps = GAMESTATE:GetCurrentSteps(pn);
+        local song = GAMESTATE:GetCurrentSong();
+        local st=GAMESTATE:GetCurrentStyle():GetStepsType();
+        local profile = PROFILEMAN:GetProfile(pn);
+        scorelist = profile:GetHighScoreList(song,steps);
+        local scores = scorelist:GetHighScores();
+        local topscore = 0;
+        if scores[1] then
+          topscore = 10*math.round(SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])/10)
+        else
+          topscore = 0
+        end;
+        local amount_of_steps = (pss:GetPossibleDancePoints()) / 3;-- overall amount of steps
+        local current_possible_p =pss:GetCurrentPossibleDancePoints();--best possible EX score at your current point in the song
+        local points = pss:GetActualDancePoints();--current EX score
+        local score_per_step = 1000000 / amount_of_steps; --Amount of SN score per step
+        local w1=pss:GetTapNoteScores('TapNoteScore_W1');--current marvelous count
+        local w2=pss:GetTapNoteScores('TapNoteScore_W2');--current perfect count
+        local w3=pss:GetTapNoteScores('TapNoteScore_W3');--current great count
+        local w4=pss:GetTapNoteScores('TapNoteScore_W4');--current good count
+        local w5=pss:GetTapNoteScores('TapNoteScore_W5');--current miss count
+        local miss=pss:GetTapNoteScores('TapNoteScore_Miss');--current miss count
+        local hd=pss:GetHoldNoteScores('HoldNoteScore_Held')--current held count
+        local nh=pss:GetHoldNoteScores('HoldNoteScore_LetGo')--current not held count
+        local mh=pss:GetHoldNoteScores('HoldNoteScore_MissedHold')--current missed hold count
+        local perfect_deduction = w2*10;--what is subtracted from a perfect
+        local great_deduction = (score_per_step*w3) - (((score_per_step * 0.6) - 10)*w3);--what is subtracted from a great
+        local good_deduction = (score_per_step*w4) - (((score_per_step * 0.2) - 10)*w4);--what is subtracted from a good
+        local good_deduction1 = (score_per_step*w5) - (((score_per_step * 0.2) - 10)*w5);--apparently there's a w5 that wasn't being accounted for
+        local miss_deduction = score_per_step*(miss+nh+mh);--what is subtracted from a miss, not held and missed hold
+        local pm = (perfect_deduction + great_deduction + good_deduction + good_deduction1 + miss_deduction) * -1;--overall deduction
+        local rpm = round(pm/10) * 10;--round deduction to tenth place
+        local currentscore = 1000000 - (rpm * -1);--determine what the current score is
+        local compare = currentscore - topscore;--compares your performance to your high score
+        if (topscore > 0) then --if you have a high score
+          if(compare>0) then --if you want to only see the deduction instead of comparing to your high score, change the variable compare to rpm
+          self:settext(compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
+          else
+          self:settext(compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
+          end;
+        else--if you don't have a high score, this will only show the deduction
+          self:settext(rpm):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
+        end;
+      end;
+    };
+  };
+end;
 
 t[#t+1] = StandardDecorationFromFileOptional("Help","Help");
 t[#t+1] = Def.Sound{


### PR DESCRIPTION
Score Tracker / Pacemaker for this theme.
I had to check each judgment individually and calculated how much of the SN score is taken off.
The tracker does not update until the next judgment is hit, which I find strange. Would prefer to find a way to fix that.
This code will show how you're currently doing compared to your high score.
If there is no high score, it will deduct from 1000000.
I have not coded it to be selected via an option. However, it could be done to use EX scoring as well.
If you want the correct font that is used in the actual theme, use _russell square in your Fonts folder. I would link mine, but GitHub does not accept that file type.
Sorry that the code is so ass.