### PR TITLE
Add PlayerNumber argument into call for NoteSkin

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/_OptionsList/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/_OptionsList/default.lua
@@ -76,7 +76,7 @@ for i=1,#fixedChar do
 end
 for i=1,#fixedNS do
     local CurrentSkin = fixedNS[i];
-    _NSKIN[i] = LoadModule("NoteskinObjLoad.lua",CurrentSkin)
+    _NSKIN[i] = LoadModule("NoteskinObjLoad.lua",{NoteSkin = CurrentSkin, Player = GAMESTATE:GetMasterPlayerNumber()})
 end;
 for i=1,#NumMini do
     local CurrentMini = NumMini[i];

--- a/Modules/NoteskinObjLoad.lua
+++ b/Modules/NoteskinObjLoad.lua
@@ -1,11 +1,13 @@
-local NoteskinToUse = ...
+local Args = ...
+local Player = Args.Player
+local NoteskinToUse = Args.NoteSkin
 local curgame = GAMESTATE:GetCurrentGame():GetName()
 
 local GameDirections = { ["dance"] = "Down", ["pump"] = "UpLeft" }
 
 local nbox
 if NoteskinToUse ~= "EXIT" then
-	nbox = NOTESKIN:LoadActorForNoteSkin( GameDirections[curgame] , "Tap Note", NoteskinToUse or "default" )
+	nbox = NOTESKIN:LoadActorForNoteSkin( GameDirections[curgame] , "Tap Note", NoteskinToUse or "default", nil, nil, nil, Player )
 else
 	nbox = Def.BitmapText{
 		Font="_avenirnext lt pro bold/20px",


### PR DESCRIPTION
With the release of OutFox Alpha 4.14.1HF, a new argument was added to LoadActorForNoteskin that allows assigning of the Player to the noteskin loader, which can be useful for noteskins that require this setting, as the default value is Player_Invalid, and that can crash some noteskins if not taken care from there (The Starlight noteskins actually perform this kind of thing as well, use Player for the receptors, but no checking if the player is not valid).

This basically fixes that by using the argument to always give the Master PlayerNumber so it has some player to generate from.