### PR TITLE
Fix Hidden/Sudden/Stealth, nil announcer error when cancelling gameplay

### DIFF
--- a/BGAnimations/ScreenGameplay decorations/Towel.lua
+++ b/BGAnimations/ScreenGameplay decorations/Towel.lua
@@ -155,13 +155,16 @@ local function AppearancePlusMain(pn)
     end
     
 	local MyValue = ReadOrCreateAppearancePlusValueForPlayer(PlayerUID,MyValue);
+
+	-- Since we handle applying appearance modifiers, let's reset all engine ones here so that none are stuck enabled.
+	GAMESTATE:ApplyPreferredModifiers(player,'No Hidden, No Sudden, No Stealth');
 	
 	if MyValue == "Hidden" then
-		GAMESTATE:AddPreferredModifiers(player,'Hidden');
+		GAMESTATE:ApplyPreferredModifiers(player,'Hidden');
 	elseif MyValue == "Sudden" then	
-		GAMESTATE:AddPreferredModifiers(player,'Sudden');
+		GAMESTATE:ApplyPreferredModifiers(player,'Sudden');
 	elseif MyValue == "Stealth" then
-		GAMESTATE:AddPreferredModifiers(player,'Stealth');
+		GAMESTATE:ApplyPreferredModifiers(player,'Stealth');
 	elseif MyValue == "Hidden+" then
 		
 		if GAMESTATE:GetCurrentStyle():GetStepsType()=="StepsType_Dance_Single" then

--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -68,7 +68,9 @@ t[#t+1] = Def.ActorFrame {
 		end,
 		-- CancelCommand doesn't seem to work, so...
 		CancelMessageCommand=function()
-			ANNOUNCER:SetCurrentAnnouncer(lastAnnouncer)
+			if lastAnnouncer then
+				ANNOUNCER:SetCurrentAnnouncer(lastAnnouncer)
+			end
 		end,
 	},
 	Def.Actor {


### PR DESCRIPTION
Previously, ScreenGameplay decorations would error out when attempting to apply any Hidden/Sudden/Stealth engine modifiers due to a non-existent GameState method being used (AddPreferredModifiers). This PR fixes that to use the correct method (ApplyPreferredModifiers) in addition to another issue regarding turning off said modifiers, since the theme itself handles applying them and there were no resets being done on load. A small nitpick was also fixed related to exiting/cancelling ScreenGameplay without the presence of an announcer.