### PR TITLE
Theme fixes

### DIFF
--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -474,8 +474,11 @@ t[#t+1] = Def.ActorFrame {
 					end
 				end
 				
-				if FILEMAN:DoesFileExist(THEME:GetPathG('', '_stages/' .. stageName ..'.png')) then
-					s:Load(THEME:GetPathG('', '_stages/' .. stageName ..'.png') )
+				--- there are only 1st up to 5th stage display graphics for now
+				if curStage <= 5 or stageName == 'final' then
+					if FILEMAN:DoesFileExist(THEME:GetPathG('', '_stages/' .. stageName ..'.png')) then
+						s:Load(THEME:GetPathG('', '_stages/' .. stageName ..'.png') )
+					end
 				end
 			end
 		end

--- a/BGAnimations/ScreenSelectMusic overlay/DefaultDeco/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/DefaultDeco/default.lua
@@ -308,7 +308,7 @@ for pn in EnabledPlayers() do
 					tier = SN2Grading.ScoreToGrade(topscore, diff)
 				end
 				if scores[1]:GetScore()>1  then
-				  self:LoadBackground(THEME:GetPathB("ScreenEvaluation decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
+				  self:LoadBackground(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
 				  self:diffusealpha(1):zoom(0.2)
 				end;
 			  else

--- a/BGAnimations/ScreenSelectMusic overlay/WheelDeco/Pane.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/WheelDeco/Pane.lua
@@ -157,7 +157,7 @@ t[#t+1] = Def.ActorFrame{
           local tier = SN2Grading.ScoreToGrade(topscore, diff)
           assert(topgrade);
           if scores[1]:GetScore()>1  then
-            self:LoadBackground(THEME:GetPathB("ScreenEvaluation decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
+            self:LoadBackground(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
             self:diffusealpha(1);
           end;
         else


### PR DESCRIPTION
- fixes grade display bug during music select screen (when default or wheel mode is selected )
- don't load course shutter stage display from 6th stage and up except final stage (no graphics available from 6th stage and onwards)