### PR TITLE
Fix two step diff

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/ADeco/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/ADeco/default.lua
@@ -65,7 +65,7 @@ end
 
 return Def.ActorFrame{
 	SongChosenMessageCommand=function(self)
-		self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
+		--self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
 	end;
 	Def.ActorFrame{
 		Name="SongInfo/Jacket",
@@ -89,4 +89,5 @@ return Def.ActorFrame{
 			s:xy(SCREEN_LEFT+160,SCREEN_TOP+180)
 		end,
 	};
+	LoadActor("../TwoPartDiff"),
 }

--- a/BGAnimations/ScreenSelectMusic overlay/CoverFlowDeco/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/CoverFlowDeco/default.lua
@@ -190,7 +190,7 @@ return Def.ActorFrame{
 	end,
     RemoveCommand=function(s) s:RemoveChild("TwoPartDiff") end,
 	SongChosenMessageCommand=function(self)
-		self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
+		--self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
 	end;
     Def.Actor{
         Name="WheelActor",
@@ -224,4 +224,5 @@ return Def.ActorFrame{
     SongInfo;
     Arrows;
     t;
+    LoadActor("../TwoPartDiff")
 }

--- a/BGAnimations/ScreenSelectMusic overlay/JukeboxDeco/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/JukeboxDeco/default.lua
@@ -118,7 +118,7 @@ return Def.ActorFrame{
 	end,
 	RemoveCommand=function(s) s:RemoveChild("TwoPartDiff") end,
 	SongChosenMessageCommand=function(self)
-		self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
+		-- self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
 	end;
 	Def.Sprite{
 		Texture="Header.png",
@@ -233,4 +233,5 @@ return Def.ActorFrame{
 	StandardDecorationFromFileOptional("StageDisplay","StageDisplay")..{
 		InitCommand=function(s) s:xy(_screen.cx-234,_screen.cy-270):zoom(1):draworder(100):halign(0) end,
 	};
+	LoadActor("../TwoPartDiff"),
 }

--- a/BGAnimations/ScreenSelectMusic overlay/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/TwoPartDiff/default.lua
@@ -1,163 +1,31 @@
---This file uses AddChildFromPath since I need to load as many actors as there are steps
---Thus there are no constructors, it will just take the current song and display for as many
---joined players. And do a lot of crazy stuff to handle two actorframes.
 local Y_SPACING = 140
 local Radar = LoadModule "DDR Groove Radar.lua"
 
-
---local song = SONGMAN:FindSong("Ace For Aces")
-local song = GAMESTATE:GetCurrentSong()
-local songSteps = SongUtil.GetPlayableSteps(song)
-
-assert(#songSteps>0,"Hey idiot, this song has no steps for your game mode")
-local numDiffs = #songSteps
---Is defining this even necessary?
-local center = math.ceil(numDiffs/2)
-
---This is the variable for holding the frame after it's compiled
-local frame = {
-	["PlayerNumber_P1"] = nil,
-	["PlayerNumber_P2"] = nil
+local af = Def.ActorFrame{
+	InitCommand=function(self)
+	end
 }
---Take a wild guess.
+
+-- Store the player's selections.
 local selection = {
 	["PlayerNumber_P1"] = nil,
 	["PlayerNumber_P2"] = nil
 }
 
+local stepsData = {}
+
 local compareSteps = LoadModule "StepsUtil.lua".CompareSteps
-for pn in EnabledPlayers() do
-	local playerSteps = GAMESTATE:GetCurrentSteps(pn)
-	for i=1,#songSteps do
-		if compareSteps(playerSteps, songSteps[i]) == 0 then
-			selection[pn] = i
+local function SetActiveSelections()
+	for pn in EnabledPlayers() do
+		local playerSteps = GAMESTATE:GetCurrentSteps(pn)
+		for i=1,#stepsData do
+			if compareSteps(playerSteps, stepsData[i]) == 0 then
+				selection[pn] = i
+			end
 		end
+		assert(selection[pn], "couldn't set selection for "..pn)
 	end
-	assert(selection[pn], "couldn't set selection for "..pn)
 end
-
-local function adjustScrollerFrame(pn)
-	for i=1,numDiffs do
-		local is_focus = (i == selection[pn])
-		frame[pn]:GetChild(i):stoptweening():decelerate(.2):zoom(is_focus and 1.2 or 1):GetChild("Highlight"):visible(is_focus)
-	end;
-end;
-
-local function genScrollerFrame(player)
-	local f = Def.ActorFrame{}
-	for i,steps in ipairs(songSteps) do
-		local diff = steps:GetDifficulty();
-		f[i] = Def.ActorFrame{
-			Name=i;
-			InitCommand=function(s) s:y((i-center)*Y_SPACING) end,
-			["OK"..player.."MessageCommand"]=function(s)
-				if i ~= selection[player] then
-					s:diffuse(color("0.3,0.3,0.3,1"))
-				end
-			end,
-			OffCommand=function(s) s:playcommand("OK"..player) end,
-			--Def.Sprite{ Texture="dummy"; };
-			Def.Sprite{
-				Texture=THEME:GetString("CustomDifficulty",ToEnumShortString(diff));
-			};
-			Def.BitmapText{
-				Font="_avenirnext lt pro bold/46px",
-				Text=IsMeterDec(steps:GetMeter()),
-				InitCommand=function(s)
-					s:y(-15):diffuse(CustomDifficultyTwoPartToColor(diff))
-				end,
-			};
-			Def.BitmapText{
-				Font="CFBPMDisplay",
-				Text=steps:GetAuthorCredit(),
-				InitCommand=function(s)
-					s:y(-40):diffuse(CustomDifficultyTwoPartToColor(diff)):maxwidth(200):zoom(0.65)
-				end,
-			};
-			Def.Sprite{
-				Texture="cursor";
-				Name="Highlight";
-				InitCommand=function(s) s:visible(i==selection[player]):diffuseramp():effectcolor1(Alpha(PlayerColor(player),0)):effectcolor2(Alpha(PlayerColor(player),1)):effectclock("beatnooffset") end,
-				["OK"..player.."MessageCommand"]=function(s)
-					s:stopeffect():diffuse(PlayerColor(player))
-				end,
-			};
-			Def.Sprite{
-				Texture="lamp",
-				InitCommand=function(s) s:queuecommand("Set"):visible(false) end,
-				SetCommand=function(s)
-					local profile;
-					local st = GAMESTATE:GetCurrentStyle():GetStepsType()
-					local steps = song:GetOneSteps(st,diff)
-
-					if PROFILEMAN:IsPersistentProfile(player) then
-						profile = PROFILEMAN:GetProfile(player)
-					else
-						profile = PROFILEMAN:GetMachineProfile()
-					end
-
-					local scorelist = profile:GetHighScoreList(song,steps)
-					local scores = scorelist:GetHighScores()
-					local topscore;
-
-					if scores[1] then
-						topscore = scores[1];
-						assert(topscore);
-                		local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                		local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-                		local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-                		local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-                		local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-                		local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-						if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-							if (greats+perfects) == 0 then
-								s:diffuse(FullComboEffectColor["JudgmentLine_W1"]):glowblink():effectperiod(0.20)
-							elseif greats == 0 then
-								s:diffuse(GameColor.Judgment["JudgmentLine_W2"]):glowshift();
-							elseif (misses+boos+goods) == 0 then
-								s:diffuse(GameColor.Judgment["JudgmentLine_W3"]):stopeffect();
-							elseif (misses+boos) == 0 then
-								s:diffuse(GameColor.Judgment["JudgmentLine_W4"]):stopeffect();
-							end;
-							s:visible(true)
-						else
-							if topscore:GetGrade() ~= 'Grade_Failed' then
-								s:visible(true):diffuse(color("#f70b9e"))
-							else
-								s:visible(true):diffuse(color("#555452"))
-							end
-						end
-					else
-						s:visible(false)
-					end
-				end
-			},
-			Def.Sprite{
-				Texture="../_ShockArrow/ShockArrowText",
-				InitCommand=function(s) s:y(10):visible(false):zoom(0.3):glowblink():effectcolor1(color("1,1,1,0.6")):effectcolor2(color("1,1,1,0")):effectperiod(0.15):queuecommand("Set") end,
-				SetCommand=function(s)
-					local song = GAMESTATE:GetCurrentSong()
-					local st = GAMESTATE:GetCurrentStyle():GetStepsType()
-					if song then
-						local steps = song:GetOneSteps(st,diff)
-						if steps then
-							if steps:GetRadarValues(player):GetValue('RadarCategory_Mines') >= 1 then
-								s:visible(true)
-							else
-								s:visible(false)
-							end
-						else
-							s:visible(false)
-						end
-					else
-						s:visible(false)
-					end
-				end,
-			}
-		};
-	end;
-	return f;
-end;
 
 local function RadarPanel(pn)
     local GR = {
@@ -212,96 +80,121 @@ local function RadarPanel(pn)
     return t
 end
 
+local function genScrollerFrame(pn)
+	local t = Def.ActorFrame{}
 
-local keyset={false,false}
-
-local function DiffInputHandler(event)
-	local pn= event.PlayerNumber
-	local button = event.button
-	if event.type == "InputEventType_Release" then return end
-	--[=[--SOUND:PlayOnce(THEME:GetPathS("_MusicWheel","Change"),true)
-	if (button == "MenuUp" or button == "MenuLeft") and selection[pn] > 1 and GAMESTATE:IsPlayerEnabled(pn) and keyset[pn] ~= 1 then
-		SOUND:PlayOnce(THEME:GetPathS("","ScreenSelectMusic difficulty harder"));
-		selection[pn] = selection[pn] - 1
-		GAMESTATE:SetCurrentSteps(pn,songSteps[selection[pn]])
-		GAMESTATE:SetPreferredDifficulty(pn,songSteps[selection[pn]]:GetDifficulty())
-		adjustScrollerFrame(pn)
-		MESSAGEMAN:Broadcast("TwoDiffLeft"..pn)
-		return false;
-	elseif (button == "MenuDown" or button == "MenuRight") and selection[pn] < numDiffs and GAMESTATE:IsPlayerEnabled(pn) and keyset[pn] ~= 1 then
-		SOUND:PlayOnce(THEME:GetPathS("","ScreenSelectMusic difficulty harder"));
-		selection[pn] = selection[pn] + 1
-		GAMESTATE:SetCurrentSteps(pn,songSteps[selection[pn]])
-		GAMESTATE:SetPreferredDifficulty(pn,songSteps[selection[pn]]:GetDifficulty())
-		MESSAGEMAN:Broadcast("TwoDiffRight"..pn)
-		adjustScrollerFrame(pn)
-		return true;
-	--]=]
-	--elseif (button == "Start") and GAMESTATE:IsPlayerEnabled(pn) then
-	if (button == "Start") and GAMESTATE:IsPlayerEnabled(pn) and not keyset[pn] and getenv("OPList") == 0 then
-		keyset[pn] = true
-		MESSAGEMAN:Broadcast("OK"..pn)
-	end;
-end;
-
-local t = Def.ActorFrame{
-	Name="TwoPartDiff",
-	InitCommand=function(s) s:visible(ThemePrefs.Get("ShowDiffSelect")) end,
-	OnCommand=function(s) s:playcommand("Off") end,
-	StartSelectingStepsMessageCommand=function(s)
-		s:sleep(0.5):queuecommand("Add")
-		diffisopen = 1
-	end,
-	SongUnchosenMessageCommand=function(s)
-		s:playcommand("Remove")
-	end,
-	RemoveCommand=function(s) SCREENMAN:GetTopScreen():RemoveInputCallback(DiffInputHandler)
-		diffisopen = 0
-		setenv("OPStop",1)
-	end,
-	AddCommand=function(s)
-		SCREENMAN:GetTopScreen():AddInputCallback(DiffInputHandler)
-		setenv("OPStop",0)
-	end,
-	OffCommand=function(s)
-		s:playcommand("Remove")
-	end,
-	Def.Sprite{
-		Texture="base.png",
-		InitCommand=function(s) s:visible(false):Center() end,
-	}
-}
-
-for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
-	t[#t+1] = Def.ActorFrame{
-		InitCommand=function(s)
-			s:xy(pn==PLAYER_1 and SCREEN_LEFT+(SCREEN_WIDTH/4.9) or SCREEN_RIGHT-(SCREEN_WIDTH/4.9),_screen.cy+30)
+	t[#t+1] = Def.DynamicActorScroller{
+		NumItemsToDraw = 5,
+		SecondsPerItem = 0.1,
+		-- LoopScroller = true,
+		OnCommand=function(self)
+			-- For more information about this Input Controller, check "Custom Input".
+			-- https://outfox.wiki/dev/theming/Theming-Custom-Input/
+	
+			-- TRICK: Make the scroller be outside of range, so by the time it comes back,
+			-- it has been loaded with the present steps data.
+			self:SetCurrentAndDestinationItem( 7 )
 		end,
-		ChangeStepsMessageCommand = function(_, param)
+		StartSelectingStepsMessageCommand=function (self)
+			local song = GAMESTATE:GetCurrentSong()
+			stepsData = SongUtil.GetPlayableSteps(song)
+			lua.ReportScriptError("i am ready with ".. #stepsData .. " items!")
+	
+			SetActiveSelections()
+	
+			-- Force the scroller to update its items.
+			self:SetCurrentAndDestinationItem( selection[pn]-1 )
+		end,
+		LoadFunction = function(self, itemIndex)
+			-- This will tell the scroller how many items will be generated for the scroller. It just needs a number.
+			-- "Call the expression with line = nil to find out the number of lines."
+	
+			-- Self is the actor represented for the actor set.
+			-- itemIndex is the item relative to the current selection from the user.
+			if self then
+				---@type Steps
+				local steps = stepsData[itemIndex+1]
+				if steps then 
+					local diff = steps:GetDifficulty()
+					local diffItem = THEME:GetString("CustomDifficulty",ToEnumShortString(diff))
+					self:GetChild("DifficultyBG"):Load( THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff/".. diffItem) )
+					self:GetChild("Meter"):settext( IsMeterDec(steps:GetMeter()) ):diffuse(CustomDifficultyTwoPartToColor(diff))
+					self:GetChild("CFBPMDisplay"):settext( steps:GetAuthorCredit() ):diffuse(CustomDifficultyTwoPartToColor(diff))
+					self:GetChild("ShockArrow"):visible( steps:GetRadarValues(pn):GetValue('RadarCategory_Mines') >= 1 )
+				end
+			end
+			return 5
+		end,
+		TransformFunction=function(self, offset, itemIndex, numItems)
+			self:y( offset * Y_SPACING )
+		end,
+		-- By the rules, this is only adding a single item, which is an ActorFrame holding a BitmapText.
+		-- The actor in this case will be provided with a ItemIndex attribute attached. This can be accessed
+		-- using self. This is only given initially and doesn't update. Use the LoadFunction to get a new
+		-- version of the value.
+		Def.ActorFrame{
+			Def.Sprite{
+				Name="DifficultyBG"
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/46px",
+				Name="Meter",
+				InitCommand=function(s)
+					s:y(-15)
+				end,
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/46px",
+				Name="CFBPMDisplay",
+				InitCommand=function(s)
+					s:y(-40):maxwidth(200):zoom(0.65)
+				end,
+			},
+			Def.Sprite{
+				Texture="cursor";
+				Name="Highlight";
+				InitCommand=function(s) s:visible(false):diffuseramp():effectcolor1(Alpha(PlayerColor(player),0)):effectcolor2(Alpha(PlayerColor(player),1)):effectclock("beatnooffset") end,
+				-- ["OK"..player.."MessageCommand"]=function(s)
+				-- 	s:stopeffect():diffuse(PlayerColor(player))
+				-- end,
+			},
+			Def.Sprite{
+				Texture="../_ShockArrow/ShockArrowText",
+				Name="ShockArrow",
+				InitCommand=function(s) s:y(10):visible(false):zoom(0.3):glowblink():effectcolor1(color("1,1,1,0.6")):effectcolor2(color("1,1,1,0")):effectperiod(0.15) end, -- :queuecommand("Set") end,
+			},
+		},
+		-- Let's add input to this scroller.
+		ChangeStepsMessageCommand=function (self, param)
 			if param.Player ~= pn then return end
 			local dir = param.Direction
 			selection[pn] = selection[pn] + dir
-			adjustScrollerFrame(pn)
-
-			local msg
-			if dir < 0 then
-				msg = "TwoDiffLeft"
-			elseif dir > 0 then
-				msg = "TwoDiffRight"
-			else return end
-			return MESSAGEMAN:Broadcast(msg..pn)
+			SCREENMAN:SystemMessage(selection[pn])
+			self:SetDestinationItem( selection[pn]-1 )
 		end,
-		genScrollerFrame(pn)..{
-			InitCommand=function(s)
-				frame[pn] = s;
-				adjustScrollerFrame(pn)
-				s:xy(pn==PLAYER_1 and 400 or -400,-40)
+	}
+
+	return t
+end
+
+for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
+	af[#af+1] = Def.ActorFrame{
+		InitCommand=function(s)
+			s:xy(pn==PLAYER_1 and SCREEN_LEFT+(SCREEN_WIDTH/4.9) or SCREEN_RIGHT-(SCREEN_WIDTH/4.9),_screen.cy+30)
+		end,
+		genScrollerFrame(pn) .. {
+			InitCommand=function(self)
+				-- frame[pn] = s;
+				-- adjustScrollerFrame(pn)
+				self:xy(pn==PLAYER_1 and 400 or -400,-40)
 			end,
-			StartSelectingStepsMessageCommand=function(s) s:addy(pn==PLAYER_1 and -SCREEN_HEIGHT*2 or SCREEN_HEIGHT*2)
+			StartSelectingStepsMessageCommand=function(self)
+				self:addy(pn==PLAYER_1 and -SCREEN_HEIGHT*2 or SCREEN_HEIGHT*2)
 				:decelerate(1):addy(pn==PLAYER_1 and SCREEN_HEIGHT*2 or -SCREEN_HEIGHT*2)
 			end,
 			RemoveCommand=function(s) s:sleep(0.7):accelerate(1):addy(pn==PLAYER_1 and SCREEN_HEIGHT*2 or -SCREEN_HEIGHT*2) end,
-		};
+		},
+		-- Now generate the difficulty info frame.
 		Def.ActorFrame{
 			StartSelectingStepsMessageCommand=function(s) s:addx(pn==PLAYER_1 and -800 or 800):decelerate(0.5):addx(pn==PLAYER_1 and 800 or -800) end,
 			RemoveCommand=function(s) s:sleep(0.7):accelerate(1):addx(pn==PLAYER_1 and -800 or 800) end,
@@ -338,21 +231,8 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 				StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
 				ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
 			};
-		};
-		--Yes I'm loading a version of the diff list that literally only has the frame removed. Fight me.
-		Def.BitmapText{
-			Font="_avenirnext lt pro bold/25px",
-			Text="Please wait...",
-			InitCommand=function(s) s:diffusealpha(0):y(60):strokecolor(Color.Black):sleep(0.4) end,
-			AnimCommand=function(s) s:finishtweening():cropright(0.2):linear(0.5):cropright(0):queuecommand("Anim") end,
-			["OK"..pn.."MessageCommand"]=function(s)
-				s:x(-100):decelerate(0.4):x(0):diffusealpha(1):queuecommand("Anim")
-			end,
-			OffCommand=function(s) 
-				s:settext("O.K.!")
-				:finishtweening():diffusealpha(1):sleep(1):decelerate(0.3):diffusealpha(0)
-			end,
-		};
+		}
 	}
 end
-return t;
+
+return af

--- a/BGAnimations/ScreenSelectMusic overlay/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/TwoPartDiff/default.lua
@@ -17,7 +17,6 @@ end
 
 local af = Def.ActorFrame{
 	InitCommand=function(s) s:visible(ThemePrefs.Get("ShowDiffSelect")) end,
-	-- OnCommand=function(s) s:playcommand("Remove") end,
 	StartSelectingStepsMessageCommand=function(s)
 		s:sleep(0.5):queuecommand("Add")
 	end,
@@ -65,37 +64,39 @@ local function RadarPanel(pn)
         {-108,72, "Air"}, --AIR
         {108,72, "Freeze"}, --FREEZE
         {120,-43, "Chaos"}, --CHAOS
-    };
+    }
     local t = Def.ActorFrame{
 		StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
 		ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
-	};
+	}
+
     t[#t+1] = Def.ActorFrame{
         Def.ActorFrame{
             Name="Radar",
             Def.Sprite{
                 Texture=THEME:GetPathB("ScreenSelectMusic","overlay/RadarHandler/GrooveRadar base.png"),
-            };
+            },
             Def.Sprite{
                 Texture=THEME:GetPathB("ScreenSelectMusic","overlay/RadarHandler/sweep.png"),
                 InitCommand = function(s) s:zoom(1.35):spin():effectmagnitude(0,0,100) end,
-            };
-            Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25));
-        };
-    };
+            },
+            Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25))
+        }
+    }
+
     for i,v in ipairs(GR) do
         t[#t+1] = Def.ActorFrame{
             InitCommand=function(s)
                 s:xy(v[1],v[2])
-            end;
+            end,
             Def.Sprite{
                 Texture=THEME:GetPathB("ScreenSelectMusic","overlay/RadarHandler/RLabels"),
                 InitCommand=function(s) s:animate(0):setstate(i-1) end,
-            };
+            },
             Def.BitmapText{
-                Font="_avenirnext lt pro bold/20px";
+                Font="_avenirnext lt pro bold/20px",
                 SetCommand=function(s)
-                    local song = GAMESTATE:GetCurrentSong();
+                    local song = GAMESTATE:GetCurrentSong()
                     if song then
                         local steps = GAMESTATE:GetCurrentSteps(pn)
                         local value = lookup_ddr_radar_values(song, steps, pn)[i]
@@ -105,8 +106,8 @@ local function RadarPanel(pn)
                     end
                     s:strokecolor(color("#1f1f1f")):y(28)
                 end,
-            };
-        };
+            }
+        }
     end
     return t
 end
@@ -127,7 +128,7 @@ local function genScrollerFrame(pn)
 			self:SetCurrentAndDestinationItem( numItems+2 )
 		end,
 		RemoveCommand=function (self)
-			self:sleep(1.7):queuecommand("On")
+			self:SetDestinationItem( numItems+2 )
 		end,
 		StartSelectingStepsMessageCommand=function (self)
 			local song = GAMESTATE:GetCurrentSong()
@@ -137,6 +138,7 @@ local function genScrollerFrame(pn)
 	
 			-- Force the scroller to update its items.
 			self:SetCurrentAndDestinationItem( selection[pn]-1 )
+			self:playcommand("CheckItem")
 		end,
 		LoadFunction = function(self, itemIndex)
 			-- This will tell the scroller how many items will be generated for the scroller. It just needs a number.
@@ -145,7 +147,6 @@ local function genScrollerFrame(pn)
 			-- Self is the actor represented for the actor set.
 			-- itemIndex is the item relative to the current selection from the user.
 			if self then
-				---@type Steps
 				local steps = stepsData[itemIndex+1]
 				self:visible( steps ~= nil )
 				if steps then 
@@ -155,12 +156,63 @@ local function genScrollerFrame(pn)
 					self:GetChild("Meter"):settext( IsMeterDec(steps:GetMeter()) ):diffuse(CustomDifficultyTwoPartToColor(diff))
 					self:GetChild("CFBPMDisplay"):settext( steps:GetAuthorCredit() ):diffuse(CustomDifficultyTwoPartToColor(diff))
 					self:GetChild("ShockArrow"):visible( steps:GetRadarValues(pn):GetValue('RadarCategory_Mines') >= 1 )
+					self:GetChild("Highlight").indexValue = itemIndex
+
+					-- Handle highscore lamp.
+					local profile
+					local song = GAMESTATE:GetCurrentSong()
+
+					if not song then return numItems end
+
+					if PROFILEMAN:IsPersistentProfile(pn) then
+						profile = PROFILEMAN:GetProfile(pn)
+					else
+						profile = PROFILEMAN:GetMachineProfile()
+					end
+
+					local scorelist = profile:GetHighScoreList(song,steps)
+					local scores = scorelist:GetHighScores()
+					local topscore
+
+					local lampActor = self:GetChild("Lamp")
+					if scores[1] then
+						topscore = scores[1]
+						assert(topscore)
+                		local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
+                		local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
+                		local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
+                		local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
+                		local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
+                		local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
+						if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
+							if (greats+perfects) == 0 then
+								lampActor:diffuse(FullComboEffectColor["JudgmentLine_W1"]):glowblink():effectperiod(0.20)
+							elseif greats == 0 then
+								lampActor:diffuse(GameColor.Judgment["JudgmentLine_W2"]):glowshift()
+							elseif (misses+boos+goods) == 0 then
+								lampActor:diffuse(GameColor.Judgment["JudgmentLine_W3"]):stopeffect()
+							elseif (misses+boos) == 0 then
+								lampActor:diffuse(GameColor.Judgment["JudgmentLine_W4"]):stopeffect()
+							end
+							lampActor:visible(true)
+						else
+							if topscore:GetGrade() ~= 'Grade_Failed' then
+								lampActor:visible(true):diffuse(color("#f70b9e"))
+							else
+								lampActor:visible(true):diffuse(color("#555452"))
+							end
+						end
+					else
+						lampActor:visible(false)
+					end
 				end
 			end
 			return numItems
 		end,
 		TransformFunction=function(self, offset, itemIndex, numItems)
 			self:y( offset * Y_SPACING )
+
+			self:diffusealpha( (offset < -3 or offset > 3) and 0 or 1 )
 		end,
 		-- By the rules, this is only adding a single item, which is an ActorFrame holding a BitmapText.
 		-- The actor in this case will be provided with a ItemIndex attribute attached. This can be accessed
@@ -181,21 +233,32 @@ local function genScrollerFrame(pn)
 				Font="_avenirnext lt pro bold/46px",
 				Name="CFBPMDisplay",
 				InitCommand=function(s)
-					s:y(-40):maxwidth(200):zoom(0.65)
+					s:y(-40):maxwidth(200):zoom(0.5)
 				end,
 			},
 			Def.Sprite{
 				Texture="cursor",
 				Name="Highlight",
 				InitCommand=function(s) s:visible(false):diffuseramp():effectcolor1(Alpha(PlayerColor(pn),0)):effectcolor2(Alpha(PlayerColor(pn),1)):effectclock("beatnooffset") end,
+				CheckItemCommand=function (self)
+					if self.indexValue then
+						local scrollerActor = self:GetParent():GetParent()
+						self:visible( self.indexValue == scrollerActor:GetDestinationItem() )
+					end
+				end,
 				["OK"..pn.."MessageCommand"]=function(self)
 					self:stopeffect():diffuse(PlayerColor(pn))
 				end,
 			},
 			Def.Sprite{
+				Name="Lamp",
+				Texture="lamp",
+				InitCommand=function(s) s:queuecommand("Set"):visible(false) end,
+			},
+			Def.Sprite{
 				Texture="../_ShockArrow/ShockArrowText",
 				Name="ShockArrow",
-				InitCommand=function(s) s:y(10):visible(false):zoom(0.3):glowblink():effectcolor1(color("1,1,1,0.6")):effectcolor2(color("1,1,1,0")):effectperiod(0.15) end, -- :queuecommand("Set") end,
+				InitCommand=function(s) s:y(10):visible(false):zoom(0.3):glowblink():effectcolor1(color("1,1,1,0.6")):effectcolor2(color("1,1,1,0")):effectperiod(0.15) end,
 			},
 		},
 		-- Let's add input to this scroller.
@@ -204,6 +267,7 @@ local function genScrollerFrame(pn)
 			local dir = param.Direction
 			selection[pn] = selection[pn] + dir
 			self:SetDestinationItem( selection[pn]-1 )
+			self:playcommand("CheckItem")
 		end,
 	}
 
@@ -221,27 +285,27 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 			end,
 			StartSelectingStepsMessageCommand=function(self)
 				self:finishtweening():y(pn==PLAYER_1 and -SCREEN_HEIGHT*2 or SCREEN_HEIGHT*2)
-				:decelerate(1):y(-40)
+				:decelerate(0.4):y(-40)
 			end,
-			RemoveCommand=function(s) s:finishtweening():sleep(0.7):accelerate(1):addy(pn==PLAYER_1 and SCREEN_HEIGHT*2 or -SCREEN_HEIGHT*2) end,
+			RemoveCommand=function(s) s:finishtweening():accelerate(0.5):addy(pn==PLAYER_1 and SCREEN_HEIGHT*2 or -SCREEN_HEIGHT*2) end,
 		},
 		-- Now generate the difficulty info frame.
 		Def.ActorFrame{
 			InitCommand=function (self)
 				self:x(pn==PLAYER_1 and -800 or 800)
 			end,
-			StartSelectingStepsMessageCommand=function(s) s:x(pn==PLAYER_1 and -800 or 800):decelerate(0.5):x(0) end,
-			RemoveCommand=function(s) s:sleep(0.7):accelerate(1):addx(pn==PLAYER_1 and -800 or 800) end,
+			StartSelectingStepsMessageCommand=function(s) s:x(pn==PLAYER_1 and -800 or 800):decelerate(0.35):x(0) end,
+			RemoveCommand=function(s) s:stoptweening():accelerate(0.35):addx(pn==PLAYER_1 and -800 or 800) end,
 			Def.ActorFrame{
 				Name="WINDOW FRAME",
 				InitCommand=function(s)
 					s:zoomx(pn==PLAYER_2 and -1 or 1)
 				end,
-				Def.Sprite{ Texture="WINDOW INNER";
+				Def.Sprite{ Texture="WINDOW INNER",
 					InitCommand=function(s) s:diffuse(color("#333333")):y(14) end,
-				};
-				Def.Sprite{ Texture="WINDOW FRAME"};
-			};
+				},
+				Def.Sprite{ Texture="WINDOW FRAME"}
+			},
 			Def.ActorFrame{
 				Name="DIFF HEADER",
 				--Blaze it
@@ -253,18 +317,18 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 				Def.Sprite{
 					Texture="Diff Text",
 				}
-			};
+			},
 			RadarPanel(pn)..{
 				InitCommand=function(s) s:diffusealpha(0) end,
 				StartSelectingStepsMessageCommand=function(s) s:sleep(0.4):smooth(0.1):diffusealpha(0.5)
 					:smooth(0.1):diffusealpha(0.3):decelerate(0.3):diffusealpha(1)
 				end,
-			};
+			},
 			loadfile(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff/_Diff.lua"))(pn)..{
 				InitCommand=function(s) s:y(-360) end,
 				StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
 				ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
-			};
+			}
 		},
 		--Yes I'm loading a version of the diff list that literally only has the frame removed. Fight me.
 		Def.BitmapText{
@@ -275,11 +339,14 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 			["OK"..pn.."MessageCommand"]=function(s)
 				s:x(-100):decelerate(0.4):x(0):diffusealpha(1):queuecommand("Anim")
 			end,
+			RemoveCommand=function (self)
+				self:stoptweening():decelerate(0.4):x(0)
+			end,
 			OffCommand=function(s) 
 				s:settext("O.K.!")
 				:finishtweening():diffusealpha(1):sleep(1):decelerate(0.3):diffusealpha(0)
 			end,
-		};
+		}
 	}
 end
 

--- a/BGAnimations/ScreenSelectMusic overlay/WheelDeco/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/WheelDeco/default.lua
@@ -102,7 +102,7 @@ return Def.ActorFrame{
 	end,
 	RemoveCommand=function(s) s:RemoveChild("TwoPartDiff") end,
 	SongChosenMessageCommand=function(self)
-		self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
+		--self:AddChildFromPath(THEME:GetPathB("ScreenSelectMusic","overlay/TwoPartDiff"));
 	end;
   loadfile(THEME:GetPathB("ScreenSelectMusic","overlay/WheelDeco/BannerHandler.lua"))();
   StandardDecorationFromFileOptional("StageDisplay","StageDisplay")..{
@@ -171,4 +171,5 @@ return Def.ActorFrame{
 		end,
 		CurrentSongChangedMessageCommand=function(s) s:queuecommand("Set") end,
 	};
+  LoadActor("../TwoPartDiff"),
 }

--- a/Modules/StepsUtil.lua
+++ b/Modules/StepsUtil.lua
@@ -1,4 +1,8 @@
-local st_rev = Enum.Reverse(StepsType)
+-- Outfox updated the StepsType enumerator to ChartType for generalized
+-- naming schemes. Check for this while processing this line.
+local stTypeToCheck = ChartType or StepsType
+
+local st_rev = Enum.Reverse(stTypeToCheck)
 local diff_rev = Enum.Reverse(Difficulty)
 
 ClearLampColors = {


### PR DESCRIPTION
This PR is to perform an update to the TwoStepDiff lua file, which takes care of selecting difficulties.

Given its original implementation using `ActorFrame:AddChildFromPath`, it crashes the game due to a race condition.
This fix rewrites the entire file to make use of dynamic ActorScrollers instead.

## Checklist

- [x] Add Dynamic scroller for items
- [x] Make selection update when changing diffs
- [x] Reimplement animations

<img width="1440" alt="Captura de pantalla 2024-03-09 a la(s) 2 46 01 a m" src="https://github.com/MidflightDigital/XX--STARLiGHT--twopointzero/assets/23246027/8ae5117e-4235-4638-97c3-89f7a5f6c264">