### PR TITLE
[Feature] Auto select style

### DIFF
--- a/BGAnimations/ScreenSelectStyle decorations/default.lua
+++ b/BGAnimations/ScreenSelectStyle decorations/default.lua
@@ -2,21 +2,21 @@ local t = LoadFallbackB()
 
 CustStage = 1
 
-local AutoSetStyle = ThemePrefs.Get('AutoSetStyle')
-if AutoSetStyle and AutoSetStyle ~= '' then
-  if AutoSetStyle == 'single'
-  or AutoSetStyle == 'double'
-  or AutoSetStyle == 'versus' then
+local AutoSelectStyle = ThemePrefs.Get('AutoSelectStyle')
+if AutoSelectStyle and AutoSelectStyle ~= '' then
+  if AutoSelectStyle == 'single'
+  or AutoSelectStyle == 'double'
+  or AutoSelectStyle == 'versus' then
     t[#t+1] = Def.Actor{
       OnCommand=function(s)
-        SCREENMAN:SystemMessage('Auto set style to: '..AutoSetStyle)
-        GAMESTATE:SetCurrentStyle(AutoSetStyle)
+        SCREENMAN:SystemMessage('Auto selected style: '..AutoSelectStyle)
+        GAMESTATE:SetCurrentStyle(AutoSelectStyle)
         SCREENMAN:SetNewScreen(Branch.AfterSelectStyle())
       end
     }
     return t
   else
-    Warning('ThemePerfs: Invalid AutoSetStyle value "'..AutoSetStyle..'", ignoring.')
+    Warning('ThemePerfs: Invalid AutoSelectStyle value "'..AutoSelectStyle..'", ignoring.')
   end
 end 
 

--- a/BGAnimations/ScreenSelectStyle decorations/default.lua
+++ b/BGAnimations/ScreenSelectStyle decorations/default.lua
@@ -1,6 +1,24 @@
-local t = LoadFallbackB();
+local t = LoadFallbackB()
 
 CustStage = 1
+
+local AutoSetStyle = ThemePrefs.Get('AutoSetStyle')
+if AutoSetStyle and AutoSetStyle ~= '' then
+  if AutoSetStyle == 'single'
+  or AutoSetStyle == 'double'
+  or AutoSetStyle == 'versus' then
+    t[#t+1] = Def.Actor{
+      OnCommand=function(s)
+        SCREENMAN:SystemMessage('Auto set style to: '..AutoSetStyle)
+        GAMESTATE:SetCurrentStyle(AutoSetStyle)
+        SCREENMAN:SetNewScreen(Branch.AfterSelectStyle())
+      end
+    }
+    return t
+  else
+    Warning('ThemePerfs: Invalid AutoSetStyle value "'..AutoSetStyle..'", ignoring.')
+  end
+end 
 
 for i=1,2 do
   t[#t+1] = Def.ActorFrame{

--- a/BGAnimations/ScreenSelectStyle decorations/default.lua
+++ b/BGAnimations/ScreenSelectStyle decorations/default.lua
@@ -2,21 +2,62 @@ local t = LoadFallbackB()
 
 CustStage = 1
 
-local AutoSelectStyle = ThemePrefs.Get('AutoSelectStyle')
-if AutoSelectStyle and AutoSelectStyle ~= '' then
-  if AutoSelectStyle == 'single'
-  or AutoSelectStyle == 'double'
-  or AutoSelectStyle == 'versus' then
+function CanSetCurrentStyle(gameName, styleName)
+  local style
+  local styleNameLower = styleName:lower()
+  for _, v in pairs(GAMEMAN:GetStylesForGame(gameName)) do
+    if v:GetName():lower() == styleNameLower then
+      style = v
+      break
+    end
+  end
+  if not style then
+    return false, 'INVALID_STYLE'
+  end
+  
+  -- https://github.com/stepmania/stepmania/blob/d55acb1ba26f1c5b5e3048d6d6c0bd116625216f/src/GameState.cpp#L3180
+  local numSidesJoined = GAMESTATE:GetNumSidesJoined()
+  local styleType = ToEnumShortString(style:GetStyleType())
+  if numSidesJoined == 2 and (styleType == 'OnePlayerOneSide' or styleType == 'OnePlayerTwoSides') then
+    return false, 'TOO_MANY_PLAYERS'
+  elseif numSidesJoined == 1 and (styleType == 'TwoPlayersTwoSides' or styleType == 'TwoPlayersSharedSides') then
+    return false, 'TOO_FEW_PLAYERS'
+  end
+  
+  return true
+end
+
+local autoSelectStyle = ThemePrefs.Get('AutoSelectStyle')
+if autoSelectStyle and autoSelectStyle ~= '' then
+  autoSelectStyle = autoSelectStyle:lower()
+  
+  local canAutoSelectStyle, reasonCode = CanSetCurrentStyle('dance', autoSelectStyle) -- We currently only support dance
+  if canAutoSelectStyle then
     t[#t+1] = Def.Actor{
       OnCommand=function(s)
-        SCREENMAN:SystemMessage('Auto selected style: '..AutoSelectStyle)
-        GAMESTATE:SetCurrentStyle(AutoSelectStyle)
+        SCREENMAN:SystemMessage('Auto selected style: ' .. autoSelectStyle)
+        GAMESTATE:SetCurrentStyle(autoSelectStyle)
         SCREENMAN:SetNewScreen(Branch.AfterSelectStyle())
       end
     }
     return t
   else
-    Warning('ThemePerfs: Invalid AutoSelectStyle value "'..AutoSelectStyle..'", ignoring.')
+    reasonCode = tostring(reasonCode)
+    
+    local reason
+    if reasonCode == 'TOO_MANY_PLAYERS' then
+      reason = 'Too many players joined for style \'' .. autoSelectStyle .. '\''
+    elseif reasonCode == 'TOO_FEW_PLAYERS' then
+      reason = 'Too few players joined for style \'' .. autoSelectStyle .. '\''
+    elseif reasonCode == 'INVALID_STYLE' then
+      reason = 'Invalid style \'' .. autoSelectStyle .. '\''
+      Warn('AutoSelectStyle theme preference is set to invalid style "' .. autoSelectStyle .. '"')
+    else
+      reason = 'Unknown reason \'' .. reasonCode .. '\''
+      Warn('Unknown CanSetCurrentStyle() reason "' .. reasonCode .. '"')
+    end
+    
+    SCREENMAN:SystemMessage('Cannot auto select style: ' .. reason .. ', please select style manually.')
   end
 end 
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -154,6 +154,7 @@ ScoreLabel=SCORE LABEL
 ##Customization Stuff##
 SystemTheme=System Options Theme
 AutoSetStyle=Auto Set Style
+AutoSelectStyle=Auto Select Style
 MachinePrefsSaveToDisk=Keep Machine Preferences
 RadarLimit=Radar Limiter
 JudgeUnderField=Judge Under Field
@@ -356,6 +357,7 @@ Hide2=
 
 ##Customization Stuff##
 AutoSetStyle=Allow the game to list all one player and two player modes at once instead of one style only. This might require a restart of StepMania (or press Shift+F2).
+AutoSelectStyle=Automatically select the style during the style selection screen. This will skip the style selection screen if set.
 RadarLimit=Enables/Disables the limiting of Groove Radar values on Music Select.
 CutIns=Determine if character art is shown when reaching combo milestones.
 JudgeUnderField=Determine if the judgments should display under the notes or not.

--- a/Scripts/02 ThemePrefs.lua
+++ b/Scripts/02 ThemePrefs.lua
@@ -129,6 +129,12 @@ local Prefs =
 		Choices = {"No", "Yes"},
 		Values = {false, true},
 	},
+	AutoSelectStyle = 
+	{
+		Default = '',
+		Choices = {'Off', 'Single', 'Double', 'Versus'},
+		Values = {'', 'single', 'double', 'versus'},
+	},
 };
 
 ThemePrefs.InitAll(Prefs)

--- a/metrics.ini
+++ b/metrics.ini
@@ -322,11 +322,12 @@ ShowHeader=false
 
 NextScreen="ScreenPHOTwON"
 PrevScreen="ScreenPHOTwON"
-LineNames="SV,BurnIn,OptionsList,PauseMenu,MachinePrefsSaveToDisk,RadarLimit,CDTITLE,gComboUnderField,JudgeUnderField,ComboPerRow,CutIns,ComboColorMode,Convert,ShowDiffSelect,ShowHTP,ENS"
+LineNames="SV,BurnIn,OptionsList,PauseMenu,AutoSelectStyle,MachinePrefsSaveToDisk,RadarLimit,CDTITLE,gComboUnderField,JudgeUnderField,ComboPerRow,CutIns,ComboColorMode,Convert,ShowDiffSelect,ShowHTP,ENS"
 #LineEXScore="lua,ThemePrefRow('EXScore')"
 LineConvert="lua,ThemePrefRow('ConvertScoresAndGrades')"
 LineComboPerRow="lua,ThemePrefRow('ComboPerRow')"
 LinegAuto="lua,ThemePrefRow('AutoSetStyle')"
+LineAutoSelectStyle="lua,ThemePrefRow('AutoSelectStyle')"
 LineMachinePrefsSaveToDisk="lua,ThemePrefRow('MachinePrefsSaveToDisk')"
 LinegComboUnderField="lua,ThemePrefRow('ComboUnderField')"
 LineJudgeUnderField="lua,ThemePrefRow('JudgeUnderField')"


### PR DESCRIPTION
Adds the option under theme preferences to auto select style between Single, Double, or Versus. When set it skips the style selection screen.

Useful if the player only have one dance pad and always play in single style, or has two dance pads and prefer to always play in double style.