### PR TITLE
[Bugfix/Refactor] Scores and Grades

### DIFF
--- a/BGAnimations/ScreenEvaluationNormal decorations/default.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/default.lua
@@ -154,12 +154,7 @@ local function FindText(pss)
   return string.format('%02d STAGE', pss:GetSongsPassed())
 end
 
-for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
-  local function m(metric)
-    metric = metric:gsub('PN', ToEnumShortString(pn))
-    return THEME:GetMetric(Var('LoadingScreen'),metric)
-  end
-  
+for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do  
   local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
   local steps = GAMESTATE:GetCurrentSteps(pn)
 
@@ -169,23 +164,7 @@ for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
   local pPrefs = ProfilePrefs.Read(profileID)
   local showEXScore = pPrefs.ex_score
 
-  t[#t+1] = ScoreAndGrade.GetGradeActor{
-      Big = true,
-      ActorConcat = {
-        Grade = {
-          OnCommand = m('GradePNOnCommand'),
-          OffCommand = m('GradePNOffCommand')
-        }
-      }
-    }..{
-    InitCommand = function(s)
-      local c = s:GetChildren()
-      c.Grade:xy(m('GradePNX'), m('GradePNY'))		
-      c.FullCombo:xy(m('RingPNX'), m('RingPNY'))
-      
-      s:playcommand('SetGrade', { Highscore = pss, Steps = steps })
-    end,
-  }
+  t[#t+1] = loadfile(THEME:GetPathB('ScreenEvaluationNormal','decorations/grade'))(pn, pss, steps)
 
   t[#t+1] = Def.ActorFrame{
     Name='Scores',
@@ -196,16 +175,17 @@ for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
         s:x(IsUsingWideScreen() and _screen.cx+500 or _screen.cx+440)
       end
       
-      s:playcommand('SetGrade', { Highscore = pss, Steps = steps })
+      s:playcommand('SetScore', { Stats = pss, Steps = steps })
     end,
     OnCommand=function(s) s:zoom(0):sleep(0.3):bounceend(0.2):zoom(2) end,
     OffCommand=function(s) s:linear(0.2):zoom(0) end,
-    ScoreAndGrade.GetScoreActorRolling{
-      Font = '_avenirnext lt pro bold/46px',
-      Load = showEXScore and 'RollingNumbersEXScore' or 'RollingNumbersEvaluation',
+    ScoreAndGrade.CreateScoreRollingActor{
+      Font='_avenirnext lt pro bold/46px',
+      Load=showEXScore and 'RollingNumbersEXScore' or 'RollingNumbersEvaluation',
       ShowEXScore = showEXScore,
-    }..{
-      InitCommand=function(s) s:strokecolor(Color.Black) end,
+      InitCommand=function(self)
+        self:strokecolor(Color.Black)
+      end,
     },
     Def.BitmapText{
       Font='_avenirnext lt pro bold/25px';

--- a/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
@@ -1,37 +1,28 @@
-local args = {...}
+local pn = ({...})[1]
 -- the only arg is arg 1, the player number
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
+
 local function m(metric)
-	metric = metric:gsub("PN", ToEnumShortString(args[1]))
-	return THEME:GetMetric(Var "LoadingScreen",metric)
+	metric = metric:gsub('PN', ToEnumShortString(pn))
+	return THEME:GetMetric(Var('LoadingScreen'),metric)
 end
 
-local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(args[1])
-
-local tier = pss:GetFailed() and 'Grade_Failed' or pss:GetGrade()
-
-if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-	tier = pss:GetFailed() and 'Grade_Failed' or SN2Grading.ScoreToGrade(pss:GetScore())
-end
-
-local ring = Def.ActorFrame {};
-
-if pss:GetFailed() == false then
-	for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
-		ring[#ring+1] = loadfile(THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/fc_ring"))(pss)..{
-			InitCommand=function(s) s:xy(m "RingPNX",m "RingPNY") end,
-		};
-	end;
-end
-
-return Def.ActorFrame{
-	ring;
-	Def.Sprite{
-		InitCommand = function(s) s:x(m "GradePNX"):y(m "GradePNY"):queuecommand("Set") end,
-		OnCommand = m "GradePNOnCommand",
-		OffCommand = m "GradePNOffCommand",
-		SetCommand= function(s)
-			s:Load(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval", ToEnumShortString(tier)))
-		end;
-	};
-};
-
+return ScoreAndGrade.GetGradeActor{
+		Big = true,
+		ActorConcat = {
+			Grade = {
+				OnCommand = m('GradePNOnCommand'),
+				OffCommand = m('GradePNOffCommand')
+			}
+		}
+	}..{
+	InitCommand = function(s)
+		local c = s:GetChildren()
+		c.Grade:xy(m('GradePNX'), m('GradePNY'))		
+		c.FullCombo:xy(m('RingPNX'), m('RingPNY'))
+		
+		local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
+		local steps = GAMESTATE:GetCurrentSteps(pn)
+		s:playcommand('SetGrade', { Highscore = pss, Steps = steps })
+	end,
+}

--- a/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
@@ -1,28 +1,40 @@
-local pn = ({...})[1]
--- the only arg is arg 1, the player number
+local args = {...}
+local pn = args[1]
+local stats = args[2]
+local steps = args[3]
 local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local function m(metric)
 	metric = metric:gsub('PN', ToEnumShortString(pn))
-	return THEME:GetMetric(Var('LoadingScreen'),metric)
+	return THEME:GetMetric(Var('LoadingScreen'), metric)
 end
 
-return ScoreAndGrade.GetGradeActor{
-		Big = true,
-		ActorConcat = {
-			Grade = {
-				OnCommand = m('GradePNOnCommand'),
-				OffCommand = m('GradePNOffCommand')
-			}
-		}
-	}..{
-	InitCommand = function(s)
-		local c = s:GetChildren()
+local GradeOnCommand = m('GradePNOnCommand')
+local GradeOffCommand = m('GradePNOffCommand')
+function RingOnCommand(self)
+	self:zoom(0):sleep(0.5):linear(0.2):zoom(0.8)
+end
+function RingOffCommand(self)
+	self:linear(0.2):zoom(0)
+end
+
+return ScoreAndGrade.CreateGradeActor{
+	Big=true,
+	InitCommand=function(self)
+		local c = self:GetChildren()
 		c.Grade:xy(m('GradePNX'), m('GradePNY'))		
 		c.FullCombo:xy(m('RingPNX'), m('RingPNY'))
 		
-		local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
-		local steps = GAMESTATE:GetCurrentSteps(pn)
-		s:playcommand('SetGrade', { Highscore = pss, Steps = steps })
+		self:playcommand('SetScore', { Stats = stats, Steps = steps })
+	end,
+	OnCommand=function(self)
+		local c = self:GetChildren()
+		GradeOnCommand(c.Grade)
+		RingOnCommand(c.FullCombo)
+	end,
+	OffCommand=function(self)
+		local c = self:GetChildren()
+		GradeOffCommand(c.Grade)
+		RingOffCommand(c.FullCombo)
 	end,
 }

--- a/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/grade/default.lua
@@ -23,7 +23,7 @@ return ScoreAndGrade.CreateGradeActor{
 	InitCommand=function(self)
 		local c = self:GetChildren()
 		c.Grade:xy(m('GradePNX'), m('GradePNY'))		
-		c.FullCombo:xy(m('RingPNX'), m('RingPNY'))
+		c.FullCombo:xy(m('RingPNX'), m('RingPNY')):fov(120):bob():effectmagnitude(0,0,20)
 		
 		self:playcommand('SetScore', { Stats = stats, Steps = steps })
 	end,

--- a/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
@@ -1,21 +1,57 @@
 local pn = ...
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local t = Def.ActorFrame {};
 -- Holy fcuk yes it's finally working (inefficient as it may be)
 local function RivalScore(pn,rival)
 	local t=Def.ActorFrame {
+		SetCommand=function(s)      
+      local c = s:GetChildren()
+			
+			local SongOrCourse, StepsOrTrail
+			if GAMESTATE:IsCourseMode() then
+				SongOrCourse = GAMESTATE:GetCurrentCourse()
+				StepsOrTrail = GAMESTATE:GetCurrentTrail(pn)
+			else
+				SongOrCourse = GAMESTATE:GetCurrentSong()
+				StepsOrTrail = GAMESTATE:GetCurrentSteps(pn)
+			end;
+      if not (SongOrCourse and StepsOrTrail) then
+        c.Score:visible(false)
+        c.GradeFrame:visible(false)
+        return
+      end
+			
+      
+      local profile
+      if PROFILEMAN:IsPersistentProfile(pn) then
+        profile = PROFILEMAN:GetProfile(pn)
+      else
+        profile = PROFILEMAN:GetMachineProfile()
+      end;
+      local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
+      local score = scores[rival]
+      if not score then
+        c.Score:visible(false)
+        c.GradeFrame:visible(false)
+        return
+      end
+      
+      s:playcommand('SetGrade', { Highscore = score, Steps = StepsOrTrail })
+    end;
+		OnCommand=function(s) s:playcommand("Set") end,
 		CurrentSongChangedMessageCommand=function(s) s:playcommand("Set") end,
 		CurrentCourseChangedMessageCommand=function(s) s:playcommand("Set") end,
 		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
-        ["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
+		["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
 		Def.BitmapText{
 			Font="_avenirnext lt pro bold/25px",
 			Text=THEME:GetString("ScreenEvaluation","RIVAL"..rival),
 			InitCommand=function(s) s:halign(1):x(-130):maxwidth(140):strokecolor(Alpha(Color.Black,0.4)) end,
 		},
 		Def.BitmapText{
-			Font="_avenirnext lt pro bold/36px",
-			InitCommand=function(s) s:zoom(0.8):halign(0):x(-100):strokecolor(Color.Black) end,
+			Font='_avenirnext lt pro bold/25px',
+			InitCommand=function(s) s:zoom(1):halign(0):x(-110):strokecolor(Color.Black) end,
 			OnCommand=function(self)
 				local SongOrCourse, StepsOrTrail;
 				if GAMESTATE:IsCourseMode() then
@@ -56,202 +92,17 @@ local function RivalScore(pn,rival)
 				end;
 			end;
 		};
-		Def.BitmapText{
-			Font="_avenirnext lt pro bold/36px",
-			InitCommand=function(s) s:x(260):halign(1):zoom(0.8) end,
-			BeginCommand=function(s) s:playcommand("Set") end,
-			SetCommand=function(self)
-				local SongOrCourse, StepsOrTrail;
-				if GAMESTATE:IsCourseMode() then
-					SongOrCourse = GAMESTATE:GetCurrentCourse();
-					StepsOrTrail = GAMESTATE:GetCurrentTrail(pn);
-				else
-					SongOrCourse = GAMESTATE:GetCurrentSong();
-					StepsOrTrail = GAMESTATE:GetCurrentSteps(pn);
-				end;
-
-				local profile, scorelist;
-				local text = "";
-				if SongOrCourse and StepsOrTrail then
-					local st = StepsOrTrail:GetStepsType();
-					local diff = StepsOrTrail:GetDifficulty();
-					local courseType = GAMESTATE:IsCourseMode() and SongOrCourse:GetCourseType() or nil;
-
-					if PROFILEMAN:IsPersistentProfile(pn) then
-						-- player profile
-						profile = PROFILEMAN:GetProfile(pn);
-					else
-						-- machine profile
-						profile = PROFILEMAN:GetMachineProfile();
-					end;
-
-					scorelist = profile:GetHighScoreList(SongOrCourse,StepsOrTrail);
-					assert(scorelist)
-					local scores = scorelist:GetHighScores();
-					local topscore=0;
-					if scores[rival] then
-						--[[if ThemePrefs.Get("ConvertScoresAndGrades") then
-							topscore = SN2Scoring.GetSN2ScoreFromHighScore(StepsOrTrail, scores[rival]:GetScore())
-						else]]
-							topscore = scores[rival]:GetScore();
-						--end
-					end;
-					assert(topscore);
-					if topscore ~= 0  then
-							local scorel3 = topscore%1000;
-							local scorel2 = (topscore/1000)%1000;
-							local scorel1 = (topscore/1000000)%1000000;
-					text = string.format("%01d"..",".."%03d"..",".."%03d",scorel1,scorel2,scorel3);
-					else
-						text = "";
-					end;
-				else
-					text = "";
-				end;
-				self:settext(text);
-			end;
-		};
-		Def.ActorFrame{
-			InitCommand=function(s) s:x(60) end,
-			Def.Quad{
-				InitCommand=function(s) s:zoom(1.2):draworder(2) end,
-					BeginCommand=function(s) s:playcommand("Set") end,
-					SetCommand=function(self)
-						local SongOrCourse, StepsOrTrail;
-						if GAMESTATE:IsCourseMode() then
-							SongOrCourse = GAMESTATE:GetCurrentCourse();
-							StepsOrTrail = GAMESTATE:GetCurrentTrail(pn);
-						else
-							SongOrCourse = GAMESTATE:GetCurrentSong();
-							StepsOrTrail = GAMESTATE:GetCurrentSteps(pn);
-						end;
-		
-						local profile, scorelist;
-						local text = "";
-						if SongOrCourse and StepsOrTrail then
-							local st = StepsOrTrail:GetStepsType();
-							local diff = StepsOrTrail:GetDifficulty();
-							local courseType = GAMESTATE:IsCourseMode() and SongOrCourse:GetCourseType() or nil;
-		
-							if PROFILEMAN:IsPersistentProfile(pn) then
-								-- player profile
-								profile = PROFILEMAN:GetProfile(pn);
-							else
-								-- machine profile
-								profile = PROFILEMAN:GetMachineProfile();
-							end;
-		
-							scorelist = profile:GetHighScoreList(SongOrCourse,StepsOrTrail);
-							assert(scorelist);
-								local scores = scorelist:GetHighScores();
-								assert(scores);
-								local topscore=0;
-								if scores[rival] then
-									--[[if ThemePrefs.Get("ConvertScoresAndGrades") then
-										topscore = SN2Scoring.GetSN2ScoreFromHighScore(StepsOrTrail, scores[rival]:GetScore())
-									else]]
-										topscore = scores[rival]:GetScore();
-									--end
-								end;
-								assert(topscore);
-								local topgrade;
-								if scores[rival] then
-									if ThemePrefs.Get("ConvertScoresAndGrades") then
-										topgrade = SN2Grading.ScoreToGrade(topscore,StepsOrTrail)
-									else
-										topgrade = scores[rival]:GetGrade();
-									end
-									assert(topgrade);
-									if scores[rival]:GetScore()>1  then
-										if scores[rival]:GetScore()==1000000 and topgrade=="Grade_Tier07" then
-											self:LoadBackground(THEME:GetPathG("","myMusicWheel/GradeDisplayEval Tier01"));
-											self:diffusealpha(1);
-										else
-											self:LoadBackground(THEME:GetPathG("","myMusicWheel/GradeDisplayEval "..ToEnumShortString(topgrade)));
-											self:diffusealpha(1);
-										end;	
-									else
-										self:diffusealpha(0);
-									end;
-								else
-									self:diffusealpha(0);
-								end;
-						else
-							self:diffusealpha(0);
-						end;
-					end;
-				};
-				Def.Sprite{
-					Texture=THEME:GetPathG("Player","Badge FullCombo"),
-					InitCommand=function(s) s:zoom(0.5):shadowlength(2):x(20):draworder(1) end,
-					BeginCommand=function(s) s:playcommand("Set") end,
-					SetCommand=function(self)
-						local SongOrCourse, StepsOrTrail;
-						if GAMESTATE:IsCourseMode() then
-							SongOrCourse = GAMESTATE:GetCurrentCourse();
-							StepsOrTrail = GAMESTATE:GetCurrentTrail(pn);
-						else
-							SongOrCourse = GAMESTATE:GetCurrentSong();
-							StepsOrTrail = GAMESTATE:GetCurrentSteps(pn);
-						end;
-		
-						local profile, scorelist;
-						local text = "";
-						if SongOrCourse and StepsOrTrail then
-							local st = StepsOrTrail:GetStepsType();
-							local diff = StepsOrTrail:GetDifficulty();
-							local courseType = GAMESTATE:IsCourseMode() and SongOrCourse:GetCourseType() or nil;
-		
-							if PROFILEMAN:IsPersistentProfile(pn) then
-								-- player profile
-								profile = PROFILEMAN:GetProfile(pn);
-							else
-								-- machine profile
-								profile = PROFILEMAN:GetMachineProfile();
-							end;
-		
-							scorelist = profile:GetHighScoreList(SongOrCourse,StepsOrTrail);
-							assert(scorelist);
-								local scores = scorelist:GetHighScores();
-								assert(scores);
-								local topscore;
-								if scores[rival] then
-									topscore = scores[rival];
-									assert(topscore);
-									local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-									local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-									local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-									local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-									local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-									local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-									if (misses+boos) == 0 and scores[rival]:GetScore() > 0 and (marvelous+perfects)>0 then
-										if (greats+perfects) == 0 then
-											self:diffuse(GameColor.Judgment["JudgmentLine_W1"]);
-											self:glowblink();
-											self:effectperiod(0.20);
-										elseif greats == 0 then
-											self:diffuse(GameColor.Judgment["JudgmentLine_W2"]);
-											self:glowshift();
-										elseif (misses+boos+goods) == 0 then
-											self:diffuse(GameColor.Judgment["JudgmentLine_W3"]);
-											self:stopeffect();
-										elseif (misses+boos) == 0 then
-											self:diffuse(GameColor.Judgment["JudgmentLine_W4"]);
-											self:stopeffect();
-										end;
-										self:diffusealpha(1);
-									else
-										self:diffusealpha(0);
-									end;
-								else
-									self:diffusealpha(0);
-								end;
-						else
-							self:diffusealpha(0);
-						end;
-					end;
-				};
+		ScoreAndGrade.GetScoreActor{	
+			Font='_avenirnext lt pro bold/25px'
+		}..{
+			Name='Score',
+			InitCommand=function(s) s:x(215):zoom(1):halign(1):strokecolor(Color.Black) end,
+		},
+		ScoreAndGrade.GetGradeActor{}..{
+			Name='GradeFrame',
+			InitCommand=function(s) s:x(245):zoom(1.1) end,
 		}
+
 	};
 	return t;
 end

--- a/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
@@ -15,20 +15,19 @@ local function RivalScore(pn,rival)
 			else
 				SongOrCourse = GAMESTATE:GetCurrentSong()
 				StepsOrTrail = GAMESTATE:GetCurrentSteps(pn)
-			end;
+			end
       if not (SongOrCourse and StepsOrTrail) then
         c.Score:visible(false)
         c.GradeFrame:visible(false)
         return
       end
 			
-      
       local profile
       if PROFILEMAN:IsPersistentProfile(pn) then
         profile = PROFILEMAN:GetProfile(pn)
       else
         profile = PROFILEMAN:GetMachineProfile()
-      end;
+      end
       local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
       local score = scores[rival]
       if not score then
@@ -36,9 +35,11 @@ local function RivalScore(pn,rival)
         c.GradeFrame:visible(false)
         return
       end
+      c.Score:visible(true)
+      c.GradeFrame:visible(true)
       
       s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
-    end;
+    end,
 		OnCommand=function(s) s:playcommand("Set") end,
 		CurrentSongChangedMessageCommand=function(s) s:playcommand("Set") end,
 		CurrentCourseChangedMessageCommand=function(s) s:playcommand("Set") end,

--- a/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
@@ -37,7 +37,7 @@ local function RivalScore(pn,rival)
         return
       end
       
-      s:playcommand('SetGrade', { Highscore = score, Steps = StepsOrTrail })
+      s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
     end;
 		OnCommand=function(s) s:playcommand("Set") end,
 		CurrentSongChangedMessageCommand=function(s) s:playcommand("Set") end,
@@ -92,15 +92,18 @@ local function RivalScore(pn,rival)
 				end;
 			end;
 		};
-		ScoreAndGrade.GetScoreActor{	
-			Font='_avenirnext lt pro bold/25px'
-		}..{
+		ScoreAndGrade.CreateScoreActor{	
 			Name='Score',
-			InitCommand=function(s) s:x(215):zoom(1):halign(1):strokecolor(Color.Black) end,
+			Font='_avenirnext lt pro bold/25px',
+			InitCommand=function(self)
+				self:x(215):zoom(1):halign(1):strokecolor(Color.Black)
+			end,
 		},
-		ScoreAndGrade.GetGradeActor{}..{
+		ScoreAndGrade.CreateGradeActor{
 			Name='GradeFrame',
-			InitCommand=function(s) s:x(245):zoom(1.1) end,
+			InitCommand=function(self)
+				self:x(245):zoom(1.1)
+			end,
 		}
 
 	};

--- a/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/scoresUnified.lua
@@ -1,12 +1,17 @@
 local pn = ...
 local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
-local t = Def.ActorFrame {};
+local t = Def.ActorFrame{}
 -- Holy fcuk yes it's finally working (inefficient as it may be)
-local function RivalScore(pn,rival)
-	local t=Def.ActorFrame {
+local function RivalScore(pn, rival)
+	return Def.ActorFrame{
+		OnCommand=function(s) s:playcommand("Set") end,
+		CurrentSongChangedMessageCommand=function(s) s:playcommand("Set") end,
+		CurrentCourseChangedMessageCommand=function(s) s:playcommand("Set") end,
+		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
+		["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
 		SetCommand=function(s)      
-      local c = s:GetChildren()
+			local c = s:GetChildren()
 			
 			local SongOrCourse, StepsOrTrail
 			if GAMESTATE:IsCourseMode() then
@@ -16,83 +21,44 @@ local function RivalScore(pn,rival)
 				SongOrCourse = GAMESTATE:GetCurrentSong()
 				StepsOrTrail = GAMESTATE:GetCurrentSteps(pn)
 			end
-      if not (SongOrCourse and StepsOrTrail) then
-        c.Score:visible(false)
-        c.GradeFrame:visible(false)
-        return
-      end
+			if not (SongOrCourse and StepsOrTrail) then
+				c.Score:visible(false)
+				c.GradeFrame:visible(false)
+				c.ScoreName:visible(false)
+				return
+			end
 			
-      local profile
-      if PROFILEMAN:IsPersistentProfile(pn) then
-        profile = PROFILEMAN:GetProfile(pn)
-      else
-        profile = PROFILEMAN:GetMachineProfile()
-      end
-      local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
-      local score = scores[rival]
-      if not score then
-        c.Score:visible(false)
-        c.GradeFrame:visible(false)
-        return
-      end
-      c.Score:visible(true)
-      c.GradeFrame:visible(true)
-      
-      s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
-    end,
-		OnCommand=function(s) s:playcommand("Set") end,
-		CurrentSongChangedMessageCommand=function(s) s:playcommand("Set") end,
-		CurrentCourseChangedMessageCommand=function(s) s:playcommand("Set") end,
-		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
-		["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
+			local profile
+			if PROFILEMAN:IsPersistentProfile(pn) then
+				profile = PROFILEMAN:GetProfile(pn)
+			else
+				profile = PROFILEMAN:GetMachineProfile()
+			end
+			local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
+			local score = scores[rival]
+			if not score then
+				c.Score:visible(false)
+				c.GradeFrame:visible(false)
+				c.ScoreName:visible(false)
+				return
+			end
+			c.Score:visible(true)
+			c.GradeFrame:visible(true)
+			c.ScoreName:visible(true)
+			c.ScoreName:settext(score:GetName())
+			
+			s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
+		end,
 		Def.BitmapText{
 			Font="_avenirnext lt pro bold/25px",
 			Text=THEME:GetString("ScreenEvaluation","RIVAL"..rival),
 			InitCommand=function(s) s:halign(1):x(-130):maxwidth(140):strokecolor(Alpha(Color.Black,0.4)) end,
 		},
 		Def.BitmapText{
+			Name='ScoreName',
 			Font='_avenirnext lt pro bold/25px',
 			InitCommand=function(s) s:zoom(1):halign(0):x(-110):strokecolor(Color.Black) end,
-			OnCommand=function(self)
-				local SongOrCourse, StepsOrTrail;
-				if GAMESTATE:IsCourseMode() then
-					SongOrCourse = GAMESTATE:GetCurrentCourse();
-					StepsOrTrail = GAMESTATE:GetCurrentTrail(pn);
-				else
-					SongOrCourse = GAMESTATE:GetCurrentSong();
-					StepsOrTrail = GAMESTATE:GetCurrentSteps(pn);
-				end;
-
-				local profile, scorelist;
-				if SongOrCourse and StepsOrTrail then
-					local st = StepsOrTrail:GetStepsType();
-					local diff = StepsOrTrail:GetDifficulty();
-					local courseType = GAMESTATE:IsCourseMode() and SongOrCourse:GetCourseType() or nil;
-
-					if PROFILEMAN:IsPersistentProfile(pn) then
-						-- player profile
-						profile = PROFILEMAN:GetProfile(pn);
-					else
-						-- machine profile
-						profile = PROFILEMAN:GetMachineProfile();
-					end;
-
-					scorelist = profile:GetHighScoreList(SongOrCourse,StepsOrTrail);
-					assert(scorelist)
-					local scores = scorelist:GetHighScores();
-					local topscore=0;
-					if scores[rival] then
-						topscore = scores[rival]:GetScore();
-					end;
-					assert(topscore);
-					if topscore ~= 0  then
-						self:settext(scores[rival]:GetName());
-					else
-						self:settext("");
-					end;
-				end;
-			end;
-		};
+		},
 		ScoreAndGrade.CreateScoreActor{	
 			Name='Score',
 			Font='_avenirnext lt pro bold/25px',
@@ -107,13 +73,12 @@ local function RivalScore(pn,rival)
 			end,
 		}
 
-	};
-	return t;
+	}
 end
 
 t[#t+1] = Def.Sprite{
 	Texture="ScoreFrame.png",
-};
+}
 
 for i=1,6 do
 	t[#t+1] = RivalScore(pn,i)..{
@@ -123,5 +88,4 @@ for i=1,6 do
 	}
 end
 
-
-return t;
+return t

--- a/BGAnimations/ScreenEvaluationNormal decorations/stats.lua
+++ b/BGAnimations/ScreenEvaluationNormal decorations/stats.lua
@@ -1,7 +1,9 @@
-local t = Def.ActorFrame{};
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
-local args = {...};
-local pn = args[1];
+local t = Def.ActorFrame{}
+
+local args = {...}
+local pn = args[1]
 
 local short_plr = ToEnumShortString(pn)
 
@@ -9,186 +11,186 @@ local profileID = GetProfileIDForPlayer(pn)
 local pPrefs = ProfilePrefs.Read(profileID)
 local ex_score = pPrefs.ex_score
 
-  local function base_x()
-    if pn == PLAYER_1 then
-      if IsUsingWideScreen() then
-          return _screen.cx-500
-      else
-        return _screen.cx-440
-      end
-    elseif pn == PLAYER_2 then
-      if IsUsingWideScreen() then
-        return _screen.cx+500
-      else
-        return _screen.cx+440
-      end
-    else
-      error("Pass a valid player number, dingus.",2)
-    end
-  end
+	local function base_x()
+		if pn == PLAYER_1 then
+			if IsUsingWideScreen() then
+					return _screen.cx-500
+			else
+				return _screen.cx-440
+			end
+		elseif pn == PLAYER_2 then
+			if IsUsingWideScreen() then
+				return _screen.cx+500
+			else
+				return _screen.cx+440
+			end
+		else
+			error("Pass a valid player number, dingus.",2)
+		end
+	end
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
+local steps = GAMESTATE:GetCurrentSteps(pn)
 
-local Combo = 	pss:MaxCombo();
+local Combo = pss:MaxCombo()
 
-local Marvelous = pss:GetTapNoteScores("TapNoteScore_W1");
-local Perfect = pss:GetTapNoteScores("TapNoteScore_W2");
-local Great = pss:GetTapNoteScores("TapNoteScore_W3");
-local Good = pss:GetTapNoteScores("TapNoteScore_W4");
-local Almost = pss:GetTapNoteScores("TapNoteScore_W5");
-local Ok = pss:GetHoldNoteScores("HoldNoteScore_Held");
-local RealMiss = pss:GetTapNoteScores("TapNoteScore_Miss");
-local LetGo = pss:GetHoldNoteScores("HoldNoteScore_LetGo");
-local Miss = RealMiss + LetGo;
+local Marvelous = pss:GetTapNoteScores("TapNoteScore_W1")
+local Perfect = pss:GetTapNoteScores("TapNoteScore_W2")
+local Great = pss:GetTapNoteScores("TapNoteScore_W3")
+local Good = pss:GetTapNoteScores("TapNoteScore_W4")
+local Almost = pss:GetTapNoteScores("TapNoteScore_W5")
+local Ok = pss:GetHoldNoteScores("HoldNoteScore_Held")
+local RealMiss = pss:GetTapNoteScores("TapNoteScore_Miss")
+local LetGo = pss:GetHoldNoteScores("HoldNoteScore_LetGo")
+local Miss = RealMiss + LetGo
 
 local seconds = pss:GetSurvivalSeconds()
 
 local function FindText(pss)
-  return string.format("%02d STAGE",pss:GetSongsPassed())
+	return string.format("%02d STAGE", pss:GetSongsPassed())
 end
-
-local Score = pss:GetScore()
-local EXScore = SN2Scoring.ComputeEXScoreFromData(SN2Scoring.GetCurrentScoreData(pss));
 
 -- Timing mode
 local TimingMode = LoadModule("Config.Load.lua")("SmartTimings","Save/OutFoxPrefs.ini") or "Unknown"
 local NoBads = (TimingMode == "DDR Modern" and true or false)
 
 t[#t+1] = Def.ActorFrame{
-  Def.Sprite{
-    Texture="judgments.png",
-    InitCommand=function(s) s:y(22)
-      if NoBads then
-        if ex_score then
-          s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments ex.png"))
-        end
-      else
-        if ex_score then
-          s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments ex almost.png"))
-        else
-          s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments almost.png"))
-        end
-      end
-    end,
-  };
-  Def.ActorFrame{
-    Name="Marvelous Line";
-    InitCommand=function(s) s:xy(-104,-99) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Marvelous):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Perfect Line";
-    InitCommand=function(s) s:xy(-104,-60) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Perfect):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Great Line";
-    InitCommand=function(s) s:xy(-104,-20) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Great):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Good Line";
-    InitCommand=function(s) s:xy(-104,20) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Good):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Almost Line";
-    InitCommand=function(s) s:xy(-104,60) if NoBads then s:visible(false) end end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Almost):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Miss Line";
-    InitCommand=function(s) s:xy(-104, (NoBads and 60 or 99)) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Miss):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.ActorFrame{
-    Name="Combo Line";
-    InitCommand=function(s) s:xy(-104, (NoBads and 99 or 139)) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:x(155)
-        self:settextf(Combo):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-  Def.BitmapText{
-    Name="EXScore";
-    Font="_avenirnext lt pro bold/36px";
-    InitCommand=function(s) s:xy(260,-74) end,
-    OnCommand=function(self)
-      if ex_score then
-        self:settextf(Score)
-      else
-        self:settextf(EXScore)
-      end
-      self:halign(1):strokecolor(Color.Black)
-    end;
-  };
-  Def.BitmapText{
-     Name="Fast Line";
-    Font="_avenirnext lt pro bold/36px";
-    InitCommand=function(s) s:xy(260,-7) end,
-    OnCommand=function(self)
-      local FastNum = getenv("numFast"..ToEnumShortString(pn))
-      self:settextf(FastNum):halign(1):strokecolor(Color.Black)
-    end;
-  };
-  Def.BitmapText{
-    Font="_avenirnext lt pro bold/36px";
-    Name="Slow Line";
-    InitCommand=function(s) s:xy(260,64) end,
-    OnCommand=function(self)
-      local FastNum = getenv("numSlow"..ToEnumShortString(pn))
-      self:settextf(FastNum):halign(1):strokecolor(Color.Black)
-    end;
-  };
-  Def.ActorFrame{
-    Name="Hold Line";
-    InitCommand=function(s) s:xy(260,132) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/36px";
-      OnCommand=function(self)
-        self:settextf(Ok):halign(1):strokecolor(Color.Black)
-      end;
-    };
-  };
-};
+	Def.Sprite{
+		Texture="judgments.png",
+		InitCommand=function(s) s:y(22)
+			if NoBads then
+				if ex_score then
+					s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments ex.png"))
+				end
+			else
+				if ex_score then
+					s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments ex almost.png"))
+				else
+					s:Load(THEME:GetPathB("ScreenEvaluationNormal","decorations/judgments almost.png"))
+				end
+			end
+		end,
+	},
+	Def.ActorFrame{
+		Name="Marvelous Line",
+		InitCommand=function(s) s:xy(-104,-99) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Marvelous):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Perfect Line",
+		InitCommand=function(s) s:xy(-104,-60) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Perfect):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Great Line",
+		InitCommand=function(s) s:xy(-104,-20) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Great):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Good Line",
+		InitCommand=function(s) s:xy(-104,20) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Good):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Almost Line",
+		InitCommand=function(s) s:xy(-104,60) if NoBads then s:visible(false) end end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Almost):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Miss Line",
+		InitCommand=function(s) s:xy(-104, (NoBads and 60 or 99)) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Miss):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.ActorFrame{
+		Name="Combo Line",
+		InitCommand=function(s) s:xy(-104, (NoBads and 99 or 139)) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:x(155)
+				self:settextf(Combo):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	},
+	Def.BitmapText{
+		Name="EXScore",
+		Font="_avenirnext lt pro bold/36px",
+		InitCommand=function(s) s:xy(260,-74) end,
+		OnCommand=function(self)
+			if ex_score then
+				local score = ScoreAndGrade.GetScore(pss, steps, false)
+				self:settextf(commify(score))
+			else
+				local exscore = ScoreAndGrade.GetScore(pss, steps, true)
+				self:settextf(exscore)
+			end
+			self:halign(1):strokecolor(Color.Black)
+		end,
+	},
+	Def.BitmapText{
+		 Name="Fast Line",
+		Font="_avenirnext lt pro bold/36px",
+		InitCommand=function(s) s:xy(260,-7) end,
+		OnCommand=function(self)
+			local FastNum = getenv("numFast"..ToEnumShortString(pn))
+			self:settextf(FastNum):halign(1):strokecolor(Color.Black)
+		end,
+	},
+	Def.BitmapText{
+		Font="_avenirnext lt pro bold/36px",
+		Name="Slow Line",
+		InitCommand=function(s) s:xy(260,64) end,
+		OnCommand=function(self)
+			local FastNum = getenv("numSlow"..ToEnumShortString(pn))
+			self:settextf(FastNum):halign(1):strokecolor(Color.Black)
+		end,
+	},
+	Def.ActorFrame{
+		Name="Hold Line",
+		InitCommand=function(s) s:xy(260,132) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/36px",
+			OnCommand=function(self)
+				self:settextf(Ok):halign(1):strokecolor(Color.Black)
+			end,
+		},
+	}
+}
 
-return t;
+return t

--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -159,9 +159,12 @@ t[#t+1] = Def.Actor{
       end
       local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
 
-      local aScore = params.Data.AScoring
-      pss:SetScore(aScore.Score)
-      pss:SetCurMaxScore(aScore.MaxScore)
+			
+			-- Lets NOT do this as it just messes up Stats.xml with theme-specific scores. Instead we should 
+			-- display different scores depending on the ThemePrefs.Get("ConvertScoresAndGrades") setting
+      -- local aScore = params.Data.AScoring
+      -- pss:SetScore(aScore.Score)
+      -- pss:SetCurMaxScore(aScore.MaxScore)
 
       
       local fast, slow = 0, 0

--- a/BGAnimations/ScreenGameplay decorations/default.lua
+++ b/BGAnimations/ScreenGameplay decorations/default.lua
@@ -144,168 +144,168 @@ t[#t+1] = Def.ActorFrame {
 };
 
 t[#t+1] = Def.Actor{
-    AfterStatsEngineMessageCommand = function(_,params)
-      local pn = params.Player
-      --So there's settings in StepMania for enabling/disabling fail for Beginner/Easy difficulties.
-      --They don't do anything normally.
-      --Yeah I don't know why we need to do this but we do and it's absolutely fucking stupid.
-      if PREFSMAN:GetPreference("FailOffForFirstStageEasy") == false and GAMESTATE:GetCurrentSteps(pn):GetDifficulty() == 'Difficulty_Easy' then
-        if GAMESTATE:GetCurrentStage() == 0 or CustStageCheck() == 1 or GAMESTATE:GetCurrentStage() == 13 then
-          GAMESTATE:SetFailTypeExplicitlySet()
-        end
-      end
-      if PREFSMAN:GetPreference("FailOffInBeginner") == false and GAMESTATE:GetCurrentSteps(pn):GetDifficulty() == 'Difficulty_Beginner' then
-        GAMESTATE:SetFailTypeExplicitlySet()
-      end
-      local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
+		AfterStatsEngineMessageCommand = function(_,params)
+			local pn = params.Player
+			--So there's settings in StepMania for enabling/disabling fail for Beginner/Easy difficulties.
+			--They don't do anything normally.
+			--Yeah I don't know why we need to do this but we do and it's absolutely fucking stupid.
+			if PREFSMAN:GetPreference("FailOffForFirstStageEasy") == false and GAMESTATE:GetCurrentSteps(pn):GetDifficulty() == 'Difficulty_Easy' then
+				if GAMESTATE:GetCurrentStage() == 0 or CustStageCheck() == 1 or GAMESTATE:GetCurrentStage() == 13 then
+					GAMESTATE:SetFailTypeExplicitlySet()
+				end
+			end
+			if PREFSMAN:GetPreference("FailOffInBeginner") == false and GAMESTATE:GetCurrentSteps(pn):GetDifficulty() == 'Difficulty_Beginner' then
+				GAMESTATE:SetFailTypeExplicitlySet()
+			end
+			local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
 
 			
 			-- Lets NOT do this as it just messes up Stats.xml with theme-specific scores. Instead we should 
 			-- display different scores depending on the ThemePrefs.Get("ConvertScoresAndGrades") setting
-      -- local aScore = params.Data.AScoring
-      -- pss:SetScore(aScore.Score)
-      -- pss:SetCurMaxScore(aScore.MaxScore)
+			-- local aScore = params.Data.AScoring
+			-- pss:SetScore(aScore.Score)
+			-- pss:SetCurMaxScore(aScore.MaxScore)
 
-      
-      local fast, slow = 0, 0
+			
+			local fast, slow = 0, 0
 
-      local fastSlow = params.Data.FastSlowRecord
-      if fastSlow then
-        fast = fastSlow.Fast
-        slow = fastSlow.Slow
-      end
+			local fastSlow = params.Data.FastSlowRecord
+			if fastSlow then
+				fast = fastSlow.Fast
+				slow = fastSlow.Slow
+			end
 
-      local short = ToEnumShortString(pn)
-      setenv("numFast"..short, fast)
-      setenv("numSlow"..short, slow)
-    end,
+			local short = ToEnumShortString(pn)
+			setenv("numFast"..short, fast)
+			setenv("numSlow"..short, slow)
+		end,
 };
 
 
 
 for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 	local playerPrefs = ProfilePrefs.Read(GetProfileIDForPlayer(pn))
-  if GAMESTATE:GetPlayMode()=="PlayMode_Oni" then
-    local trailHasSpeedMod = false;
-    local trailHasAppearanceMode = false;
-    local curTrail = GAMESTATE:GetCurrentTrail(pn):GetTrailEntries()
-    local temp = #curTrail
+	if GAMESTATE:GetPlayMode()=="PlayMode_Oni" then
+		local trailHasSpeedMod = false;
+		local trailHasAppearanceMode = false;
+		local curTrail = GAMESTATE:GetCurrentTrail(pn):GetTrailEntries()
+		local temp = #curTrail
 
-    if curTrail[1] then
-      for i=1,temp do
-        local modString = curTrail[temp]:GetNormalModifiers()
-        if string.find(modString,"x") or string.find(modString,"X") then
-          trailHasSpeedMod = true;
-        end
-        if string.find(modString,"Hidden") or string.find(modString,"Sudden") or string.find(modString,"Stealth") then
-          trailHasAppearanceMode = true;
-        end
-      end
-    end
-    if not trailHasSpeedMod then
-      t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/SpeedKill"))();
-    end
-    if not trailHasAppearanceMode then
+		if curTrail[1] then
+			for i=1,temp do
+				local modString = curTrail[temp]:GetNormalModifiers()
+				if string.find(modString,"x") or string.find(modString,"X") then
+					trailHasSpeedMod = true;
+				end
+				if string.find(modString,"Hidden") or string.find(modString,"Sudden") or string.find(modString,"Stealth") then
+					trailHasAppearanceMode = true;
+				end
+			end
+		end
+		if not trailHasSpeedMod then
+			t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/SpeedKill"))();
+		end
+		if not trailHasAppearanceMode then
 		t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/Towel"))(pn);
-    end
-  else
-    t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/SpeedKill"))();
-    t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/Towel"))(pn);
-  end
-  t[#t+1] = Def.ActorFrame{
-    InitCommand=function(s) s:y(_screen.cy-346):draworder(-1)
-      if IsUsingWideScreen() then
-        s:x(pn==PLAYER_1 and _screen.cx-494 or _screen.cx+494)
-      else
-        s:x(pn==PLAYER_1 and _screen.cx-320 or _screen.cx+320)
-      end
-	  if GAMESTATE:GetPlayerState(pn):GetPlayerOptions('ModsLevel_Current'):Reverse() == 1 then
+		end
+	else
+		t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/SpeedKill"))();
+		t[#t+1] = loadfile(THEME:GetPathB("ScreenGameplay","decorations/Towel"))(pn);
+	end
+	t[#t+1] = Def.ActorFrame{
+		InitCommand=function(s) s:y(_screen.cy-346):draworder(-1)
+			if IsUsingWideScreen() then
+				s:x(pn==PLAYER_1 and _screen.cx-494 or _screen.cx+494)
+			else
+				s:x(pn==PLAYER_1 and _screen.cx-320 or _screen.cx+320)
+			end
+		if GAMESTATE:GetPlayerState(pn):GetPlayerOptions('ModsLevel_Current'):Reverse() == 1 then
 		s:y(_screen.cy-246)
-	  else
+		else
 		s:y(_screen.cy-346)
-	  end
-	  s:visible(playerPrefs.targetscore ~= "Off")
-    end,
-    OnCommand=function(s) s:zoom(0):sleep(0.3):bounceend(0.2):zoom(1) end,
-    OffCommand=function(s) s:linear(0.2):zoom(0) end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/25px";
-      JudgmentMessageCommand=function(self)
-        self:y(256)
-        local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn);
-        local steps = GAMESTATE:GetCurrentSteps(pn);
-        local song = GAMESTATE:GetCurrentSong();
-        local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-        local profile = PROFILEMAN:GetProfile(pn);
-        scorelist = profile:GetHighScoreList(song,steps);
-        local scores = scorelist:GetHighScores();
-        local topscore = 0;
-        if scores[1] then
-          topscore = 10*math.round(SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])/10)
-        else
-          topscore = 0
-        end;
-        local amount_of_steps = (pss:GetPossibleDancePoints()) / 3;-- overall amount of steps
-        local current_possible_p =pss:GetCurrentPossibleDancePoints();--best possible EX score at your current point in the song
-        local points = pss:GetActualDancePoints();--current EX score
-        local score_per_step = 1000000 / amount_of_steps; --Amount of SN score per step
-        local w1=pss:GetTapNoteScores('TapNoteScore_W1');--current marvelous count
-        local w2=pss:GetTapNoteScores('TapNoteScore_W2');--current perfect count
-        local w3=pss:GetTapNoteScores('TapNoteScore_W3');--current great count
-        local w4=pss:GetTapNoteScores('TapNoteScore_W4');--current good count
-        local w5=pss:GetTapNoteScores('TapNoteScore_W5');--current miss count
-        local miss=pss:GetTapNoteScores('TapNoteScore_Miss');--current miss count
-        local hd=pss:GetHoldNoteScores('HoldNoteScore_Held')--current held count
-        local nh=pss:GetHoldNoteScores('HoldNoteScore_LetGo')--current not held count
-        local mh=pss:GetHoldNoteScores('HoldNoteScore_MissedHold')--current missed hold count
-        local perfect_deduction = w2*10;--what is subtracted from a perfect
-        local great_deduction = (score_per_step*w3) - (((score_per_step * 0.6) - 10)*w3);--what is subtracted from a great
-        local good_deduction = (score_per_step*w4) - (((score_per_step * 0.2) - 10)*w4);--what is subtracted from a good
-        local good_deduction1 = (score_per_step*w5) - (((score_per_step * 0.2) - 10)*w5);--apparently there's a w5 that wasn't being accounted for
-        local miss_deduction = score_per_step*(miss+nh+mh);--what is subtracted from a miss, not held and missed hold
-        local pm = (perfect_deduction + great_deduction + good_deduction + good_deduction1 + miss_deduction) * -1;--overall deduction
-        local rpm = round(pm/10) * 10;--round deduction to tenth place
-        local currentscore = 1000000 - (rpm * -1);--determine what the current score is
-        local compare = currentscore - topscore;--compares your performance to your high score
-        if (topscore > 0) then --if you have a high score
-          if(compare>0) then --if you want to only see the deduction instead of comparing to your high score, change the variable compare to rpm
-          self:settext('+'..compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
-          else
-          self:settext('-'..compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
-          end;
-        else--if you don't have a high score, this will only show the deduction
-          self:settext(rpm):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
-        end;
-      end;
-    };
-  };
+		end
+		s:visible(playerPrefs.targetscore ~= "Off")
+		end,
+		OnCommand=function(s) s:zoom(0):sleep(0.3):bounceend(0.2):zoom(1) end,
+		OffCommand=function(s) s:linear(0.2):zoom(0) end,
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/25px";
+			JudgmentMessageCommand=function(self)
+				self:y(256)
+				local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn);
+				local steps = GAMESTATE:GetCurrentSteps(pn);
+				local song = GAMESTATE:GetCurrentSong();
+				local st=GAMESTATE:GetCurrentStyle():GetStepsType();
+				local profile = PROFILEMAN:GetProfile(pn);
+				scorelist = profile:GetHighScoreList(song,steps);
+				local scores = scorelist:GetHighScores();
+				local topscore = 0;
+				if scores[1] then
+					topscore = 10*math.round(SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])/10)
+				else
+					topscore = 0
+				end;
+				local amount_of_steps = (pss:GetPossibleDancePoints()) / 3;-- overall amount of steps
+				local current_possible_p =pss:GetCurrentPossibleDancePoints();--best possible EX score at your current point in the song
+				local points = pss:GetActualDancePoints();--current EX score
+				local score_per_step = 1000000 / amount_of_steps; --Amount of SN score per step
+				local w1=pss:GetTapNoteScores('TapNoteScore_W1');--current marvelous count
+				local w2=pss:GetTapNoteScores('TapNoteScore_W2');--current perfect count
+				local w3=pss:GetTapNoteScores('TapNoteScore_W3');--current great count
+				local w4=pss:GetTapNoteScores('TapNoteScore_W4');--current good count
+				local w5=pss:GetTapNoteScores('TapNoteScore_W5');--current miss count
+				local miss=pss:GetTapNoteScores('TapNoteScore_Miss');--current miss count
+				local hd=pss:GetHoldNoteScores('HoldNoteScore_Held')--current held count
+				local nh=pss:GetHoldNoteScores('HoldNoteScore_LetGo')--current not held count
+				local mh=pss:GetHoldNoteScores('HoldNoteScore_MissedHold')--current missed hold count
+				local perfect_deduction = w2*10;--what is subtracted from a perfect
+				local great_deduction = (score_per_step*w3) - (((score_per_step * 0.6) - 10)*w3);--what is subtracted from a great
+				local good_deduction = (score_per_step*w4) - (((score_per_step * 0.2) - 10)*w4);--what is subtracted from a good
+				local good_deduction1 = (score_per_step*w5) - (((score_per_step * 0.2) - 10)*w5);--apparently there's a w5 that wasn't being accounted for
+				local miss_deduction = score_per_step*(miss+nh+mh);--what is subtracted from a miss, not held and missed hold
+				local pm = (perfect_deduction + great_deduction + good_deduction + good_deduction1 + miss_deduction) * -1;--overall deduction
+				local rpm = round(pm/10) * 10;--round deduction to tenth place
+				local currentscore = 1000000 - (rpm * -1);--determine what the current score is
+				local compare = currentscore - topscore;--compares your performance to your high score
+				if (topscore > 0) then --if you have a high score
+					if(compare>0) then --if you want to only see the deduction instead of comparing to your high score, change the variable compare to rpm
+					self:settext('+'..compare):diffuse(color("#0a7cfc")):strokecolor(Color.Black)--blue, feel free to change it to whatever you want
+					else
+					self:settext('-'..compare):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
+					end;
+				else--if you don't have a high score, this will only show the deduction
+					self:settext(rpm):diffuse(color("#ed0972")):strokecolor(Color.Black)--hot pink, you can change this too
+				end;
+			end;
+		};
+	};
 end
 
 t[#t+1] = Def.ActorFrame{
-    Def.Sprite{
-      Name="SFrame Light",
-      Texture="stageframe/light_normal",
-      InitCommand=function(s)
-        s:xy(_screen.cx,SCREEN_TOP+16)
-        if IsAnExtraStage() then
-            s:Load(THEME:GetPathB("ScreenGameplay","decorations/stageframe/light_extra"))
-        end
-      end,
-      OnCommand=function(s)
+		Def.Sprite{
+			Name="SFrame Light",
+			Texture="stageframe/light_normal",
+			InitCommand=function(s)
+				s:xy(_screen.cx,SCREEN_TOP+16)
+				if IsAnExtraStage() then
+						s:Load(THEME:GetPathB("ScreenGameplay","decorations/stageframe/light_extra"))
+				end
+			end,
+			OnCommand=function(s)
 				s:diffuseshift():effectcolor1(color("1,1,1,1")):effectcolor2(color("1,1,1,0.75")):effectclock('beatnooffset')
 			end
-    };
-    Def.Sprite{
-        Name="StageFrame",
-        Texture="stageframe/normal",
-        InitCommand=function(s)
-            s:xy(_screen.cx,SCREEN_TOP+52)
-            if IsAnExtraStage() then
-                s:Load(THEME:GetPathB("ScreenGameplay","decorations/stageframe/extra"))
-            end
-        end,
-    };
-    loadfile(THEME:GetPathB("ScreenGameplay","decorations/scoreframe/default.lua"))();
+		};
+		Def.Sprite{
+				Name="StageFrame",
+				Texture="stageframe/normal",
+				InitCommand=function(s)
+						s:xy(_screen.cx,SCREEN_TOP+52)
+						if IsAnExtraStage() then
+								s:Load(THEME:GetPathB("ScreenGameplay","decorations/stageframe/extra"))
+						end
+				end,
+		};
+		loadfile(THEME:GetPathB("ScreenGameplay","decorations/scoreframe/default.lua"))();
 };
 
 for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
@@ -351,9 +351,9 @@ t[#t+1] = Def.BitmapText{
 };
 
 t[#t+1] = Def.Sound{
-  File=THEME:GetPathS("","MusicWheel expand"),
-  Name="sound",
-  SupportPan=true
+	File=THEME:GetPathS("","MusicWheel expand"),
+	Name="sound",
+	SupportPan=true
 };
 
 local function GetTimeSigs()

--- a/BGAnimations/ScreenSelectMusic decorations/Types/Banner/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/Banner/default.lua
@@ -1,221 +1,130 @@
 local SongAttributes = LoadModule "SongAttributes.lua"
 local Radar = LoadModule "DDR Groove Radar.lua"
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local PS = Def.ActorFrame{};
 for pn in EnabledPlayers() do
-  PS[#PS+1] = loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/Types/Banner/TwoPart.lua"))(pn);
-  PS[#PS+1] = Def.ActorFrame{
-    InitCommand=function(s) s:xy(pn==PLAYER_1 and SCREEN_LEFT+200 or SCREEN_RIGHT-200,IsUsingWideScreen() and _screen.cy+220 or _screen.cy-240) end,
-    CurrentSongChangedMessageCommand=function(s) s:queuecommand("Set") end,
-		["CurrentSteps" .. ToEnumShortString(pn) .. "ChangedMessageCommand"]=function(s) s:stoptweening():queuecommand("Set") end,
-    loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/RadarHandler"))(pn);
-    Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25))..{
-			OnCommand=function(s) s:zoom(0):rotationz(-360):decelerate(0.4):zoom(1):rotationz(0) end,
-      OffCommand=function(s) s:sleep(0.3):decelerate(0.3):rotationz(-360):zoom(0) end,
-    };
-    Def.BitmapText{
-		Font="_avenirnext lt pro bold/42px",
-      	InitCommand=function(s) s:shadowlengthy(5):y(-170):zoom(0) end,
-      	OnCommand=function(s) s:sleep(0.3):bounceend(0.25):zoom(0.75) end,
-		OffCommand=function(s) s:sleep(0.5):bouncebegin(0.25):zoom(0) end,
-		SetCommand=function(s)
-				if GAMESTATE:GetCurrentSong() and GAMESTATE:GetCurrentSteps(pn) then
-					s:settext(THEME:GetString("CustomDifficulty",ToEnumShortString(GAMESTATE:GetCurrentSteps(pn):GetDifficulty())))
-					s:diffuse(CustomDifficultyToColor(ToEnumShortString(GAMESTATE:GetCurrentSteps(pn):GetDifficulty())))
-				else
-					s:settext("")
-				end
-			end,
-	};
-    Def.BitmapText{
-			Font="CFBPMDisplay",
-			InitCommand=function(s) s:y(130):diffuse(color("#dff0ff")):strokecolor(color("#00baff")):maxwidth(200) end,
-			OnCommand=function(s) s:diffusealpha(0):zoomx(3):sleep(0.3):decelerate(0.3):diffusealpha(1):zoomx(1) end,
-			OffCommand=function(s) s:accelerate(0.3):zoomx(3):diffusealpha(0) end,
-			SetCommand=function(s)
-				if GAMESTATE:GetCurrentSong() and GAMESTATE:GetCurrentSteps(pn) then
-          local sa = GAMESTATE:GetCurrentSteps(pn):GetAuthorCredit()
-					s:settext(sa ~= "" and sa or "" )
-				else
-					s:settext("")
-				end
-			end,
-		};
-    Def.BitmapText{
-		Name="Score",
-			Font="_avenirnext lt pro bold/36px",
-			InitCommand=function(s) s:y(220):strokecolor(Color.Black) end,
-			OnCommand=function(s) s:diffusealpha(0):zoomx(3):sleep(0.3):decelerate(0.3):diffusealpha(1):zoomx(1) end,
-			OffCommand=function(s) s:accelerate(0.3):zoomx(3):diffusealpha(0) end,
-			SetCommand=function(s)
-				local song = GAMESTATE:GetCurrentSong()
-				local topscore = 0
-				if song then
-					local steps = GAMESTATE:GetCurrentSteps(pn)
-					if steps then
-						local profile, scorelist;
-						if PROFILEMAN:IsPersistentProfile(pn) then
-							profile = PROFILEMAN:GetProfile(pn)
-						else
-							profile = PROFILEMAN:GetMachineProfile()
-						end
-						scorelist = profile:GetHighScoreList(song,steps)
-						local scores = scorelist:GetHighScores()
-						if scores[1] then
-							if ThemePrefs.Get("ConvertScoresAndGrades") then
-								topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-							else
-								topscore = scores[1]:GetScore()
-							end
-						end
-					end
-					if topscore ~= 0 then
-						local scorel3 = topscore%1000
-						local scorel2 = (topscore/1000)%1000
-						local scorel1 = (topscore/1000000)%1000000
-						s:visible(true):settextf("%01d"..",".."%03d"..",".."%03d",scorel1,scorel2,scorel3)
-					else
-						s:visible(false)
-					end;
-				else
-					s:settext(""):visible(false)
-				end
-			end,
-		};
-    Def.Quad{
-    	InitCommand=function(s) s:y(170):zoom(0.15) end,
-		OnCommand=function(s) s:diffusealpha(0):sleep(0.3):decelerate(0.3):diffusealpha(1) end,
-		OffCommand=function(s) s:accelerate(0.3):diffusealpha(0) end,
-		  SetCommand=function(self)
+	PS[#PS+1] = loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/Types/Banner/TwoPart.lua"))(pn);
+	PS[#PS+1] = Def.ActorFrame{
+		InitCommand=function(s) s:xy(pn==PLAYER_1 and SCREEN_LEFT+200 or SCREEN_RIGHT-200,IsUsingWideScreen() and _screen.cy+220 or _screen.cy-240) end,
+		CurrentSongChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		CurrentCourseChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		['CurrentSteps'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		['CurrentTrail'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		SetCommand=function(self)
+			local c = self:GetChildren()
+		
 			local song = GAMESTATE:GetCurrentSong()
 			local steps = GAMESTATE:GetCurrentSteps(pn)
-	  
-			local profile, scorelist;
-			local text = "";
-			if song and steps then
-			  local st = steps:GetStepsType();
-			  local diff = steps:GetDifficulty();
-	  
-			  if PROFILEMAN:IsPersistentProfile(pn) then
-				profile = PROFILEMAN:GetProfile(pn);
-			  else
-				profile = PROFILEMAN:GetMachineProfile();
-			  end;
-	  
-			  scorelist = profile:GetHighScoreList(song,steps)
-			  assert(scorelist);
-			  local scores = scorelist:GetHighScores();
-			  assert(scores);
-			  local topscore=0;
-			  if scores[1] then
-				topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-			  end;
-	  
-			  local tier
-			  if scores[1] then
-				local tier = scores[1]:GetGrade();
-				if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-					tier = SN2Grading.ScoreToGrade(topscore, diff)
-				end
-				if scores[1]:GetScore()>1  then
-				  self:LoadBackground(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
-				  self:diffusealpha(1):zoom(0.15)
-				end;
-			  else
-				self:diffusealpha(0)
-			  end;
+			if not (song and steps) then
+				c.Score:visible(false)
+				c.Grade:visible(false)
+				return
+			end
+			
+			local difficulty = ToEnumShortString(steps:GetDifficulty())
+			c.DiffName:visible(true)
+				:settext(THEME:GetString('CustomDifficulty', difficulty))
+				:diffuse(CustomDifficultyToColor(difficulty))
+				
+			local credits = steps:GetAuthorCredit()
+			if credits == '' then
+				c.ChartArtist:visible(false)
 			else
-			  self:diffusealpha(0)
-			end;
-		  end;
-		};
-		Def.ActorFrame{
-			Name="FC Ring",
-			InitCommand=function(s) s:xy(20,180) end,
+				c.ChartArtist:visible(true):settext(credits)
+			end
+				
+			local profile
+			if PROFILEMAN:IsPersistentProfile(pn) then
+				profile = PROFILEMAN:GetProfile(pn)
+			else
+				profile = PROFILEMAN:GetMachineProfile()
+			end
+			local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+			local score = scores[1]
+			
+			if not score then
+				c.Score:visible(false)
+				c.Grade:visible(false)
+				return
+			end
+			c.Score:visible(true)
+			c.Grade:visible(true)
+			
+			self:playcommand('SetScore', { Stats = score, Steps = steps })
+		end,
+		loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/RadarHandler"))(pn),
+		Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25))..{
+			OnCommand=function(s) s:zoom(0):rotationz(-360):decelerate(0.4):zoom(1):rotationz(0) end,
+			OffCommand=function(s) s:sleep(0.3):decelerate(0.3):rotationz(-360):zoom(0) end,
+		},
+		Def.BitmapText{
+			Name='DiffName',
+			Font="_avenirnext lt pro bold/42px",
+			InitCommand=function(s) s:shadowlengthy(5):y(-170):zoom(0) end,
+			OnCommand=function(s) s:sleep(0.3):bounceend(0.25):zoom(0.75) end,
+			OffCommand=function(s) s:sleep(0.5):bouncebegin(0.25):zoom(0) end,
+		},
+		Def.BitmapText{
+			Name='ChartArtist',
+			Font='CFBPMDisplay',
+			InitCommand=function(s) s:y(130):diffuse(color('#dff0ff')):strokecolor(color('#00baff')):maxwidth(200) end,
 			OnCommand=function(s) s:diffusealpha(0):zoomx(3):sleep(0.3):decelerate(0.3):diffusealpha(1):zoomx(1) end,
 			OffCommand=function(s) s:accelerate(0.3):zoomx(3):diffusealpha(0) end,
-			SetCommand=function(self)
-				local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-				local song=GAMESTATE:GetCurrentSong();
+		},
+		ScoreAndGrade.CreateScoreRollingActor{
+			Name='Score',
+			Font='_avenirnext lt pro bold/36px',
+			Load='RollingNumbersSongData',
+			InitCommand=function(self)
+				self:y(220):strokecolor(Color.Black)
+			end,
+			OnCommand=function(self)
+				self:diffusealpha(0):zoomx(3):sleep(0.3):decelerate(0.3):diffusealpha(1):zoomx(1)
+			end,
+			OffCommand=function(self)
+				self:accelerate(0.3):zoomx(3):diffusealpha(0)
+			end,
+		},
+		ScoreAndGrade.CreateGradeActor{
+			Name='Grade',
+			Big=true,
+			InitCommand=function(self)
+				self:y(170):zoom(0.15)
+				self:GetChild('FullCombo'):zoom(1.5)
+			end,
+			OnCommand=function(self)
+				self:diffusealpha(0):sleep(0.3):decelerate(0.3):diffusealpha(1)
+			end,
+			OffCommand=function(self)
+				self:accelerate(0.3):diffusealpha(0)
+			end,
+		},
+	};
+	PS[#PS+1] = loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/_ShockArrow/default.lua"))(pn)..{
+		InitCommand=function(s)
+				s:xy(pn==PLAYER_1 and _screen.cx-340 or _screen.cx+340,_screen.cy):zoom(0.5)
+		end,
+		SetCommand=function(s)
+				local song = GAMESTATE:GetCurrentSong()
 				if song then
-					local steps = GAMESTATE:GetCurrentSteps(pn);
-			  
-					if PROFILEMAN:IsPersistentProfile(pn) then
-						profile = PROFILEMAN:GetProfile(pn);
+						local steps = GAMESTATE:GetCurrentSteps(pn)
+						if steps then
+								if steps:GetRadarValues(pn):GetValue('RadarCategory_Mines') >= 1 then
+										s:queuecommand("Anim")
+								else
+										s:queuecommand("Hide")
+								end
 						else
-						profile = PROFILEMAN:GetMachineProfile();
-					end;
-					local scorelist = profile:GetHighScoreList(song,steps);
-					assert(scorelist);
-					local scores = scorelist:GetHighScores();
-					assert(scores);
-					local topscore;
-					if scores[1] then
-						topscore = scores[1];
-						assert(topscore);
-						local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-						local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-						local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-						local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-						local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-						local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-						if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-							if (greats+perfects) == 0 then
-								self:GetChild("color"):diffuse(GameColor.Judgment["JudgmentLine_W1"])
-								:glowblink():effectperiod(0.20)
-							elseif greats == 0 then
-								self:GetChild("color"):diffuse(GameColor.Judgment["JudgmentLine_W2"]):glowshift()
-							elseif (misses+boos+goods) == 0 then
-								self:GetChild("color"):diffuse(GameColor.Judgment["JudgmentLine_W3"]):stopeffect();
-							elseif (misses+boos) == 0 then
-								self:GetChild("color"):diffuse(GameColor.Judgment["JudgmentLine_W4"]):stopeffect();
-							end;
-							self:diffusealpha(1);
-						else
-							self:diffusealpha(0);
-						end;
-					else
-						self:diffusealpha(0);
-					end;
+								s:queuecommand("Hide")
+						end
 				else
-					self:diffusealpha(0);
-				end;
-			end;
-			Def.Sprite{
-				Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/star.png"),
-				InitCommand=function(self) self:zoom(0.3):spin():effectmagnitude(0,0,170) end;
-			},
-			Def.Sprite{
-				Name="color",
-				Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/colorstar.png"),
-				InitCommand=function(self) self:zoom(0.3):spin():effectmagnitude(0,0,170) end;
-			},
-		};
-  };
-  PS[#PS+1] = loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/_ShockArrow/default.lua"))(pn)..{
-    InitCommand=function(s)
-        s:xy(pn==PLAYER_1 and _screen.cx-340 or _screen.cx+340,_screen.cy):zoom(0.5)
-    end,
-    SetCommand=function(s)
-        local song = GAMESTATE:GetCurrentSong()
-        if song then
-            local steps = GAMESTATE:GetCurrentSteps(pn)
-            if steps then
-                if steps:GetRadarValues(pn):GetValue('RadarCategory_Mines') >= 1 then
-                    s:queuecommand("Anim")
-                else
-                    s:queuecommand("Hide")
-                end
-            else
-                s:queuecommand("Hide")
-            end
-        else
-            s:queuecommand("Hide")
-        end
-    end,
-    CurrentSongChangedMessageCommand=function(s) s:stoptweening():queuecommand("Set") end,
-    ["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:stoptweening():queuecommand("Set") end,
-    OffCommand=function(s) s:queuecommand("Hide") end,	
+						s:queuecommand("Hide")
+				end
+		end,
+		CurrentSongChangedMessageCommand=function(s) s:stoptweening():queuecommand("Set") end,
+		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:stoptweening():queuecommand("Set") end,
+		OffCommand=function(s) s:queuecommand("Hide") end,	
 }
 
 	if PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") then
@@ -227,11 +136,11 @@ for pn in EnabledPlayers() do
 end
 
 return Def.ActorFrame{
-  Def.Actor{
-    Name="WheelActor",
-    BeginCommand=function(s)
+	Def.Actor{
+		Name="WheelActor",
+		BeginCommand=function(s)
 		local mw = SCREENMAN:GetTopScreen():GetChild("MusicWheel")
-      	mw:xy(_screen.cx,_screen.cy+240):draworder(-1)
+				mw:xy(_screen.cx,_screen.cy+240):draworder(-1)
 	end,
 	OnCommand=function(s)
 		local mw = SCREENMAN:GetTopScreen():GetChild("MusicWheel")
@@ -239,100 +148,100 @@ return Def.ActorFrame{
 	end,
 	OffCommand=function(s)
 		local mw = SCREENMAN:GetTopScreen():GetChild("MusicWheel")
-    	mw:bouncebegin(0.15):zoomx(3):diffusealpha(0)
-    end,
-  };
-  Def.ActorFrame{
-    InitCommand=function(self)
-      self:xy(_screen.cx,SCREEN_BOTTOM+604):valign(1)
-    end;
-    StartSelectingStepsMessageCommand=function(self)
-      self:stoptweening():decelerate(0.5):y(SCREEN_BOTTOM)
-    end;
-    SongUnchosenMessageCommand=function(self)
-      self:stoptweening():decelerate(0.25):y(SCREEN_BOTTOM+604)
-    end;
-    OffCommand=function(self)
-      self:stoptweening():decelerate(0.25):y(SCREEN_BOTTOM+604)
-    end;
-    Def.Quad{
-      InitCommand=function(self)
-        self:valign(1):setsize(SCREEN_WIDTH,604):y(4)
-        :diffuse(color("0,0,0,0.5")):diffusebottomedge(color("0.5,0.3,1,0.5")):blend(Blend.Multiply)
-      end;
-    };
-    Def.Sprite{
-      Texture="backerthing",
-      InitCommand=function(s) s:valign(1):y(0) end,
-    };
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/25px",
-      Text="&MENULEFT;&MENURIGHT; TO SELECT DIFFICULTY  &MENUUP;&MENUDOWN; TO CANCEL  &START; TO CONFIRM",
-      InitCommand=function(s) s:y(-70):strokecolor(Color.Black) end,
-    };
-  };
-  
-  Def.Quad{
-    InitCommand=function(s) s:MaskSource():xy(_screen.cx,_screen.cy-118):setsize(612,112) end,
-  };
-  Def.ActorFrame{
-    InitCommand=function(s) s:xy(_screen.cx+10,_screen.cy-8):MaskDest():ztestmode("ZTestMode_WriteOnPass") end,
-    OnCommand=function(s) s:addy(-100):sleep(0.3):decelerate(0.2):addy(100) end,
-    OffCommand=function(s) s:sleep(0.2):bouncebegin(0.175):zoomy(0) end,
-    CurrentSongChangedMessageCommand = function(s) s:queuecommand("Set") end,
-    CurrentCourseChangedMessageCommand = function(s) s:queuecommand("Set") end,
-    ChangedLanguageDisplayMessageCommand = function(s) s:queuecommand("Set") end,
-    SetCommand=function(s)
-      local song = GAMESTATE:GetCurrentSong()
-      local mw = SCREENMAN:GetTopScreen():GetChild("MusicWheel")
-      if not mw then return end
-      if song then
-        s:GetChild("Title"):visible(true):settext(song:GetDisplayFullTitle())
-        :diffuse(SongAttributes.GetMenuColor(song)):strokecolor(ColorDarkTone(SongAttributes.GetMenuColor(song)))
-        s:GetChild("Artist"):visible(true):settext(song:GetDisplayArtist()):diffuse(SongAttributes.GetMenuColor(song)):strokecolor(ColorDarkTone(SongAttributes.GetMenuColor(song)))
-      elseif mw:GetSelectedType('WheelItemDataType_Section') then
-        s:GetChild("Title"):visible(true):settext(SongAttributes.GetGroupName(mw:GetSelectedSection()))
-        :diffuse(SongAttributes.GetGroupColor(mw:GetSelectedSection())):strokecolor(ColorDarkTone(SongAttributes.GetGroupColor(mw:GetSelectedSection())))
-        s:GetChild("Artist"):visible(false):settext("")
-      else
-        s:GetChild("Title"):visible(true):settext("")
-        s:GetChild("Artist"):visible(false):settext("")
-      end
-    end,
-    Def.Sprite{
-      Texture="songbox.png",
-      InitCommand=function(s)
-        if GAMESTATE:IsAnExtraStage() then
-          s:Load(THEME:GetPathB("ScreenSelectMusic","decorations/Banner/extra_songbox"))
-        end
-      end,
-    };
-    Def.BitmapText{
-      Name="Title",
-      Font="_avenir next demi bold/20px";
-      InitCommand=function(s) s:maxwidth(480):strokecolor(Alpha(Color.Black,0.5)):y(-35) end,
-    };
-    Def.BitmapText{
-      Name="Artist",
-      Font="_avenir next demi bold/20px";
-      InitCommand=function(s) s:maxwidth(480):y(-10):strokecolor(Alpha(Color.Black,0.5)) end,
-    };
-    loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/Types/Default/BPM"))(0.5)..{
-      InitCommand=function(s) s:y(18) end,
-    };
-    loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/_CDTITLE.lua"))(320,-10)..{
-      InitCommand=function(s)
-        s:visible(ThemePrefs.Get("CDTITLE"))
-      end,
-    }
-  };
-  PS;
-  StandardDecorationFromFileOptional("Help","Help")..{
+			mw:bouncebegin(0.15):zoomx(3):diffusealpha(0)
+		end,
+	};
+	Def.ActorFrame{
+		InitCommand=function(self)
+			self:xy(_screen.cx,SCREEN_BOTTOM+604):valign(1)
+		end;
+		StartSelectingStepsMessageCommand=function(self)
+			self:stoptweening():decelerate(0.5):y(SCREEN_BOTTOM)
+		end;
+		SongUnchosenMessageCommand=function(self)
+			self:stoptweening():decelerate(0.25):y(SCREEN_BOTTOM+604)
+		end;
+		OffCommand=function(self)
+			self:stoptweening():decelerate(0.25):y(SCREEN_BOTTOM+604)
+		end;
+		Def.Quad{
+			InitCommand=function(self)
+				self:valign(1):setsize(SCREEN_WIDTH,604):y(4)
+				:diffuse(color("0,0,0,0.5")):diffusebottomedge(color("0.5,0.3,1,0.5")):blend(Blend.Multiply)
+			end;
+		};
+		Def.Sprite{
+			Texture="backerthing",
+			InitCommand=function(s) s:valign(1):y(0) end,
+		};
+		Def.BitmapText{
+			Font="_avenirnext lt pro bold/25px",
+			Text="&MENULEFT;&MENURIGHT; TO SELECT DIFFICULTY  &MENUUP;&MENUDOWN; TO CANCEL  &START; TO CONFIRM",
+			InitCommand=function(s) s:y(-70):strokecolor(Color.Black) end,
+		};
+	};
+	
+	Def.Quad{
+		InitCommand=function(s) s:MaskSource():xy(_screen.cx,_screen.cy-118):setsize(612,112) end,
+	};
+	Def.ActorFrame{
+		InitCommand=function(s) s:xy(_screen.cx+10,_screen.cy-8):MaskDest():ztestmode("ZTestMode_WriteOnPass") end,
+		OnCommand=function(s) s:addy(-100):sleep(0.3):decelerate(0.2):addy(100) end,
+		OffCommand=function(s) s:sleep(0.2):bouncebegin(0.175):zoomy(0) end,
+		CurrentSongChangedMessageCommand = function(s) s:queuecommand("Set") end,
+		CurrentCourseChangedMessageCommand = function(s) s:queuecommand("Set") end,
+		ChangedLanguageDisplayMessageCommand = function(s) s:queuecommand("Set") end,
+		SetCommand=function(s)
+			local song = GAMESTATE:GetCurrentSong()
+			local mw = SCREENMAN:GetTopScreen():GetChild("MusicWheel")
+			if not mw then return end
+			if song then
+				s:GetChild("Title"):visible(true):settext(song:GetDisplayFullTitle())
+				:diffuse(SongAttributes.GetMenuColor(song)):strokecolor(ColorDarkTone(SongAttributes.GetMenuColor(song)))
+				s:GetChild("Artist"):visible(true):settext(song:GetDisplayArtist()):diffuse(SongAttributes.GetMenuColor(song)):strokecolor(ColorDarkTone(SongAttributes.GetMenuColor(song)))
+			elseif mw:GetSelectedType('WheelItemDataType_Section') then
+				s:GetChild("Title"):visible(true):settext(SongAttributes.GetGroupName(mw:GetSelectedSection()))
+				:diffuse(SongAttributes.GetGroupColor(mw:GetSelectedSection())):strokecolor(ColorDarkTone(SongAttributes.GetGroupColor(mw:GetSelectedSection())))
+				s:GetChild("Artist"):visible(false):settext("")
+			else
+				s:GetChild("Title"):visible(true):settext("")
+				s:GetChild("Artist"):visible(false):settext("")
+			end
+		end,
+		Def.Sprite{
+			Texture="songbox.png",
+			InitCommand=function(s)
+				if GAMESTATE:IsAnExtraStage() then
+					s:Load(THEME:GetPathB("ScreenSelectMusic","decorations/Banner/extra_songbox"))
+				end
+			end,
+		};
+		Def.BitmapText{
+			Name="Title",
+			Font="_avenir next demi bold/20px";
+			InitCommand=function(s) s:maxwidth(480):strokecolor(Alpha(Color.Black,0.5)):y(-35) end,
+		};
+		Def.BitmapText{
+			Name="Artist",
+			Font="_avenir next demi bold/20px";
+			InitCommand=function(s) s:maxwidth(480):y(-10):strokecolor(Alpha(Color.Black,0.5)) end,
+		};
+		loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/Types/Default/BPM"))(0.5)..{
+			InitCommand=function(s) s:y(18) end,
+		};
+		loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/_CDTITLE.lua"))(320,-10)..{
+			InitCommand=function(s)
+				s:visible(ThemePrefs.Get("CDTITLE"))
+			end,
+		}
+	};
+	PS;
+	StandardDecorationFromFileOptional("Help","Help")..{
 	StartSelectingStepsMessageCommand=function(self)
 		self:diffusealpha(0)
 	end;
-	  SongUnchosenMessageCommand=function(self)
+		SongUnchosenMessageCommand=function(self)
 		self:diffusealpha(1)
 	end;
-  }
+	}
 }

--- a/BGAnimations/ScreenSelectMusic decorations/Types/CoverFlow/Difficulty/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/CoverFlow/Difficulty/default.lua
@@ -1,3 +1,5 @@
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
+
 local t = Def.ActorFrame{
     InitCommand=function(s) s:xy(_screen.cx,_screen.cy+310) end,
     OnCommand=function(s) s:addy(SCREEN_HEIGHT/2):sleep(0.2):decelerate(0.2):addy(-SCREEN_HEIGHT/2) end,
@@ -254,163 +256,62 @@ local function DrawDifListItem(diff, pn)
     }
     for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
       Item[#Item+1] = Def.ActorFrame{
-        Def.BitmapText{
-          Name="Score";
-          Font="_avenirnext lt pro bold/20px";
-          InitCommand=function(s) s:x(pn==PLAYER_2 and 260 or -260) end,
-          SetCommand=function(self)
-              self:settext("")
-            
-              local st=GAMESTATE:GetCurrentStyle():GetStepsType()
-              local song=GAMESTATE:GetCurrentSong()
-              if song then
-                 if song:HasStepsTypeAndDifficulty(st,diff) then
-                   local steps = song:GetOneSteps(st,diff)
-            
-                  if PROFILEMAN:IsPersistentProfile(pn) then
-                    profile = PROFILEMAN:GetProfile(pn)
-                  else
-                    profile = PROFILEMAN:GetMachineProfile()
-                  end;
-            
-                  scorelist = profile:GetHighScoreList(song,steps)
-                  local scores = scorelist:GetHighScores()
-                  local topscore = 0
-            
-                  if scores[1] then
-                    if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-                      topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-                    else
-                      topscore = scores[1]
-                    end
-                  end;
-            
-                  self:strokecolor(Color.Black)
-                  self:diffusealpha(1)
-            
-                  if topscore ~= 0 then
-                    self:settext(commify(topscore))
-                  end;
-                end;
-              end;
-            end;
-          };
-          Def.ActorFrame{
-            InitCommand=function(s) s:x(pn==PLAYER_2 and 176 or -186) end,
-            Def.Sprite{
-              Texture=THEME:GetPathG("Player","Badge FullCombo"),
-              InitCommand=function(s) s:shadowlength(1):zoom(0):xy(18,4) end,
-              OffCommand=function(s) s:decelerate(0.05):diffusealpha(0) end,
-              SetCommand=function(self)
-                local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-                local song=GAMESTATE:GetCurrentSong();
-                local course = GAMESTATE:GetCurrentCourse();
-                if song then
-                  if song:HasStepsTypeAndDifficulty(st,diff) then
-                    local steps = song:GetOneSteps( st, diff );
-                    if PROFILEMAN:IsPersistentProfile(pn) then
-                      profile = PROFILEMAN:GetProfile(pn);
-                    else
-                      profile = PROFILEMAN:GetMachineProfile();
-                    end;
-                    scorelist = profile:GetHighScoreList(song,steps);
-                    assert(scorelist);
-                    local scores = scorelist:GetHighScores();
-                    assert(scores);
-                    local topscore;
-                    if scores[1] then
-                      topscore = scores[1];
-                      assert(topscore);
-                      local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                      local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-                      local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-                      local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-                      local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-                      local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-                      if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-                        if (greats+perfects) == 0 then
-                          self:diffuse(GameColor.Judgment["JudgmentLine_W1"]);
-                          self:glowblink();
-                          self:effectperiod(0.20);
-                          self:zoom(0.5);
-                        elseif greats == 0 then
-                          self:diffuse(GameColor.Judgment["JudgmentLine_W2"]);
-                          self:glowshift();
-                          self:zoom(0.5);
-                        elseif (misses+boos+goods) == 0 then
-                          self:diffuse(GameColor.Judgment["JudgmentLine_W3"]);
-                          self:stopeffect();
-                          self:zoom(0.5);
-                        elseif (misses+boos) == 0 then
-                          self:diffuse(GameColor.Judgment["JudgmentLine_W4"]);
-                          self:stopeffect();
-                          self:zoom(0.5);
-                        end;
-                        self:diffusealpha(0.8);
-                      else
-                        self:diffusealpha(0);
-                      end;
-                    else
-                      self:diffusealpha(0);
-                    end;
-                  else
-                    self:diffusealpha(0);
-                  end;
-                else
-                  self:diffusealpha(0);
-                end;
-              end
-            };
-            Def.Quad{
-              Name="Grade";
-              SetCommand=function(self)
-              local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-              local song=GAMESTATE:GetCurrentSong();
-              if song then
-                if song:HasStepsTypeAndDifficulty(st,diff) then
-                  local steps = song:GetOneSteps(st, diff)
-                  if PROFILEMAN:IsPersistentProfile(pn) then
-                    profile = PROFILEMAN:GetProfile(pn)
-                  else
-                    profile = PROFILEMAN:GetMachineProfile()
-                  end
-        
-                  scorelist = profile:GetHighScoreList(song,steps)
-                  local scores = scorelist:GetHighScores()
-        
-                  local topscore=0
-                  if scores[1] then
-                    topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-                  end
-        
-                  local topgrade
-                  if scores[1] then
-                    topgrade = scores[1]:GetGrade();
-                    local tier = SN2Grading.ScoreToGrade(topscore, diff)
-                    assert(topgrade);
-                    if scores[1]:GetScore()>1  then
-                      if topgrade == 'Grade_Failed' then
-                        self:LoadBackground(THEME:GetPathG("","myMusicWheel/GradeDisplayEval Failed"));
-                      else
-                        self:LoadBackground(THEME:GetPathG("myMusicWheel/GradeDisplayEval",ToEnumShortString(tier)));
-                      end;
-                      self:diffusealpha(1);
-                    else
-                      self:diffusealpha(0);
-                    end;
-                  else
-                    self:diffusealpha(0);
-                  end;
-                else
-                  self:diffusealpha(0);
-                end;
-              else
-                self:diffusealpha(0);
-              end;
-            end;
-            };
-          }
-        }
+				CurrentSongChangedMessageCommand=function(s) s:queuecommand('Set') end,
+				CurrentCourseChangedMessageCommand=function(s) s:queuecommand('Set') end,
+				['CurrentSteps'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+				['CurrentTrail'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+				SetCommand=function(self)
+					local c = self:GetChildren()
+				
+					local song = GAMESTATE:GetCurrentSong()
+					local stepType = GAMESTATE:GetCurrentStyle():GetStepsType()
+					local steps
+					if song then
+						steps = song:GetOneSteps(stepType, diff)
+					end
+					if not (song and steps) then
+						c.Score:visible(false)
+						c.Grade:visible(false)
+						return
+					end
+						
+					local profile
+					if PROFILEMAN:IsPersistentProfile(pn) then
+						profile = PROFILEMAN:GetProfile(pn)
+					else
+						profile = PROFILEMAN:GetMachineProfile()
+					end
+					local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+					local score = scores[1]
+					
+					if not score then
+						c.Score:visible(false)
+						c.Grade:visible(false)
+						return
+					end
+					c.Score:visible(true)
+					c.Grade:visible(true)
+					
+					self:playcommand('SetScore', { Stats = score, Steps = steps })
+				end,
+				ScoreAndGrade.CreateScoreActor{
+					Name='Score',
+          Font='_avenirnext lt pro bold/20px',
+					InitCommand=function(self)
+						self:x(pn==PLAYER_2 and 260 or -260):strokecolor(Color.Black)
+					end,
+				},
+				ScoreAndGrade.CreateGradeActor{
+					Name='Grade',
+					AlternativeFC=true,
+					InitCommand=function(self)
+						self:x(pn==PLAYER_2 and 176 or -186)
+					end,
+					OffCommand=function(self)
+						self:decelerate(0.05):diffusealpha(0)
+					end,
+				},
+			}
     end
     return Item
 end;

--- a/BGAnimations/ScreenSelectMusic decorations/Types/Default/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/Default/default.lua
@@ -1,6 +1,7 @@
 local numwh = THEME:GetMetric("MusicWheel","NumWheelItems")+2
-local SongAttributes = LoadModule "SongAttributes.lua"
-local Radar = LoadModule "DDR Groove Radar.lua"
+local SongAttributes = LoadModule()'SongAttributes.lua')
+local Radar = LoadModule('DDR Groove Radar.lua')
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local Arrows = Def.ActorFrame{};
 for i=1,2 do
@@ -53,86 +54,87 @@ for i=1,2 do
 end;
 
 
-local t = Def.ActorFrame{};
+local PlayerFrames = Def.ActorFrame{}
 
 for pn in EnabledPlayers() do
-	t[#t+1] = Def.ActorFrame{
-		InitCommand=function(s) s:xy(pn==PLAYER_1 and (IsUsingWideScreen() and _screen.cx-566 or _screen.cx-420) or (IsUsingWideScreen() and _screen.cx+566 or _screen.cx+420),_screen.cy-200):zoom(0) end,
-		OnCommand=function(s) s:sleep(0.3):bounceend(0.25):zoom(1) end,
-		OffCommand=function(s) s:sleep(0.5):bouncebegin(0.25):zoom(0) end,
-		CurrentSongChangedMessageCommand=function(s) s:stoptweening():queuecommand("Set") end,
-		["CurrentSteps" .. ToEnumShortString(pn) .. "ChangedMessageCommand"]=function(s) s:stoptweening():queuecommand("Set") end,
-		SetCommand=function(s)
+	local t = Def.ActorFrame{
+		CurrentSongChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		CurrentCourseChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		['CurrentSteps'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		['CurrentTrail'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		SetCommand=function(self)
+			local c = self:GetChildren()
+			local c2 = self:GetChild('SongStats'):GetChildren()
+		
 			local song = GAMESTATE:GetCurrentSong()
-			local topscore = 0
-			local profile, scorelist;
-
+			local steps = GAMESTATE:GetCurrentSteps(pn)
+			if not (song and steps) then
+				c.Grade:visible(false)
+				c2.Score:visible(false)
+				c2.DiffName:visible(false)
+				c2.Meter:visible(false)
+				c2.ChartArtist:visible(false)
+				return
+			end
+			
+			local difficulty = ToEnumShortString(steps:GetDifficulty())
+			c2.DiffName:visible(true)
+				:settext(THEME:GetString('CustomDifficulty', difficulty))
+				:diffuse(CustomDifficultyToColor(difficulty))
+			c2.Meter:visible(true)
+				:settext(IsMeterDec(steps:GetMeter()))
+			
+			local credits = steps:GetAuthorCredit()
+			if credits == '' then
+				c2.ChartArtist:visible(false)
+			else
+				c2.ChartArtist:visible(true):settext(credits)
+			end
+				
+			local profile
 			if PROFILEMAN:IsPersistentProfile(pn) then
 				profile = PROFILEMAN:GetProfile(pn)
 			else
 				profile = PROFILEMAN:GetMachineProfile()
 			end
-
-			local diff = s:GetChild("DiffName")
-			local score = s:GetChild("Score")
-			local meter = s:GetChild("Meter")
-			local ca = s:GetChild("ChartArtist")
-
-			if song then
-				local steps = GAMESTATE:GetCurrentSteps(pn)
-				if steps then
-
-					scorelist = profile:GetHighScoreList(song,steps)
-					local scores = scorelist:GetHighScores()
-					if scores[1] then
-						if ThemePrefs.Get("ConvertScoresAndGrades") then
-							topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-						else
-							topscore = scores[1]:GetScore()
-						end
-					end
-
-					diff:visible(true):settext(THEME:GetString("CustomDifficulty",ToEnumShortString(steps:GetDifficulty())))
-					:diffuse(CustomDifficultyToColor(ToEnumShortString(steps:GetDifficulty())))
-
-					meter:visible(true):settext(IsMeterDec(GAMESTATE:GetCurrentSteps(pn):GetMeter()))
-
-					if steps:GetAuthorCredit() ~= "" then
-						ca:settext(steps:GetAuthorCredit()):visible(true)
-					else
-						ca:settext(""):visible(false)
-					end
-
-					if topscore ~= 0 then
-						local scorel3 = topscore%1000
-						local scorel2 = (topscore/1000)%1000
-						local scorel1 = (topscore/1000000)%1000000
-						score:visible(true):settextf("%01d"..",".."%03d"..",".."%03d",scorel1,scorel2,scorel3)
-					else
-						score:visible(false):settext("")
-					end
-				end
-			else
-				diff:settext(""):visible(false)
-				score:visible(false):settext("")
-				meter:visible(false):settext("")
-				ca:settext(""):visible(false)
+			local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+			local score = scores[1]
+			
+			if not score then
+				c.Grade:visible(false)
+				c2.Score:visible(false)
+				return
 			end
+			c.Grade:visible(true)
+			c2.Score:visible(true)
+			
+			self:playcommand('SetScore', { Stats = score, Steps = steps })
 		end,
+	}
+	PlayerFrames[#PlayerFrames+1] = t
+	
+	t[#t+1] = Def.ActorFrame{
+		Name='SongStats',
+		InitCommand=function(s) s:xy(pn==PLAYER_1 and (IsUsingWideScreen() and _screen.cx-566 or _screen.cx-420) or (IsUsingWideScreen() and _screen.cx+566 or _screen.cx+420),_screen.cy-200):zoom(0) end,
+		OnCommand=function(s) s:sleep(0.3):bounceend(0.25):zoom(1) end,
+		OffCommand=function(s) s:sleep(0.5):bouncebegin(0.25):zoom(0) end,
 		Def.Sprite{
 			Texture=THEME:GetPathG("","_shared/RadarBase.png"),
 			InitCommand=function(s) s:y(10):blend(Blend.Add):zoom(1.35):diffuse(ColorMidTone(PlayerColor(pn))):diffusealpha(0.75) end,
 		},
-		Radar.create_ddr_groove_radar("radar",0,20,pn,350,Alpha(PlayerColor(pn),0.25));
+		Radar.create_ddr_groove_radar("radar",0,20,pn,350,Alpha(PlayerColor(pn),0.25)),
 		Def.BitmapText{
 			Name="DiffName",
 			Font="_avenirnext lt pro bold/42px",
 			InitCommand=function(s) s:shadowlengthy(5):y(-180) end,
 		},
-		Def.BitmapText{
-			Name="Score",
-			Font="_avenirnext lt pro bold/46px",
-			InitCommand=function(s) s:y(200):strokecolor(Color.Black) end,
+		ScoreAndGrade.CreateScoreRollingActor{
+			Name='Score',
+			Font='_avenirnext lt pro bold/46px',
+			Load='RollingNumbersSongData',
+			InitCommand=function(self)
+				self:y(200):strokecolor(Color.Black)
+			end,
 		},
 		Def.BitmapText{
 			Name="Meter",
@@ -159,6 +161,7 @@ for pn in EnabledPlayers() do
 		InitCommand=function(s)
 			s:xy(pn==PLAYER_1 and _screen.cx-340 or _screen.cx+340,_screen.cy+50):zoom(0.6)
 		end,
+		OffCommand=function(s) s:queuecommand("Hide") end,
 		SetCommand=function(s)
 			local song = GAMESTATE:GetCurrentSong()
 			if song then
@@ -176,134 +179,22 @@ for pn in EnabledPlayers() do
 				s:queuecommand("Hide")
 			end
 		end,
-		CurrentSongChangedMessageCommand=function(s) s:stoptweening():queuecommand("Set") end,
-		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:stoptweening():queuecommand("Set") end,
-		OffCommand=function(s) s:queuecommand("Hide") end,	
 	}
-	t[#t+1] = Def.ActorFrame{
-		InitCommand=function(s) 
-			s:zoom(0):halign(pn==PLAYER_1 and 1 or 0)
+	t[#t+1] = ScoreAndGrade.CreateGradeActor{
+		Name='Grade',
+		Big=true,
+		InitCommand=function(self)
+			self:halign(pn==PLAYER_1 and 1 or 0)
 			if IsUsingWideScreen() then
-				s:x(pn==PLAYER_1 and _screen.cx-280 or _screen.cx+280):y(_screen.cy-360)
+				self:x(pn==PLAYER_1 and _screen.cx-280 or _screen.cx+280):y(_screen.cy-360)
 			else
-				s:x(pn==PLAYER_1 and _screen.cx-260 or _screen.cx+260):y(_screen.cy-320)
+				self:x(pn==PLAYER_1 and _screen.cx-260 or _screen.cx+260):y(_screen.cy-320)
 			end
+			self:GetChild('FullCombo'):zoom(1.5):addy(50)
 		end,
-		OnCommand=function(s) s:sleep(0.3):bounceend(0.25):zoom(1) end,
+		OnCommand=function(s) s:zoom(0):sleep(0.3):bounceend(0.25):zoom(0.2) end,
 		OffCommand=function(s) s:sleep(0.5):bouncebegin(0.25):zoom(0) end,
-		CurrentSongChangedMessageCommand=function(s) s:queuecommand("Set") end,
-		["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
-		["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s) s:queuecommand("Set") end,
-		CurrentCourseChangedMessageCommand=function(s) s:queuecommand("Set") end,
-		Def.Quad{
-			SetCommand=function(self)
-			  local song = GAMESTATE:GetCurrentSong()
-			  local steps = GAMESTATE:GetCurrentSteps(pn)
-		
-			  local profile, scorelist;
-			  local text = "";
-			  if song and steps then
-				local st = steps:GetStepsType();
-				local diff = steps:GetDifficulty();
-		
-				if PROFILEMAN:IsPersistentProfile(pn) then
-				  profile = PROFILEMAN:GetProfile(pn);
-				else
-				  profile = PROFILEMAN:GetMachineProfile();
-				end;
-		
-				scorelist = profile:GetHighScoreList(song,steps)
-				assert(scorelist);
-				local scores = scorelist:GetHighScores();
-				assert(scores);
-				local topscore=0;
-				if scores[1] then
-				  topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-				end;
-		
-				local tier
-				if scores[1] then
-				  local tier = scores[1]:GetGrade();
-				  if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-					  tier = SN2Grading.ScoreToGrade(topscore, diff)
-				  end
-				  if scores[1]:GetScore()>1  then
-					self:LoadBackground(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
-					self:diffusealpha(1):zoom(0.2)
-				  end;
-				else
-				  self:diffusealpha(0)
-				end;
-			  else
-				self:diffusealpha(0)
-			  end;
-			end;
-		  };
-		Def.ActorFrame{
-			Name="FC Ring",
-			InitCommand=function(s) s:xy(40,20) end,
-			SetCommand=function(self)
-				local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-				local song=GAMESTATE:GetCurrentSong();
-				if song then
-					local steps = GAMESTATE:GetCurrentSteps(pn);
-			  
-					if PROFILEMAN:IsPersistentProfile(pn) then
-						profile = PROFILEMAN:GetProfile(pn);
-						else
-						profile = PROFILEMAN:GetMachineProfile();
-					end;
-					local scorelist = profile:GetHighScoreList(song,steps);
-					assert(scorelist);
-					local scores = scorelist:GetHighScores();
-					assert(scores);
-					local topscore;
-					if scores[1] then
-						topscore = scores[1];
-						assert(topscore);
-						local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-						local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-						local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-						local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-						local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-						local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-						if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-							if (greats+perfects) == 0 then
-								self:GetChild("Color"):diffuse(GameColor.Judgment["JudgmentLine_W1"])
-								:glowblink():effectperiod(0.20)
-							elseif greats == 0 then
-								self:GetChild("Color"):diffuse(GameColor.Judgment["JudgmentLine_W2"])
-								:glowshift()
-							elseif (misses+boos+goods) == 0 then
-								self:GetChild("Color"):diffuse(GameColor.Judgment["JudgmentLine_W3"])
-								:stopeffect()
-							elseif (misses+boos) == 0 then
-								self:GetChild("Color"):diffuse(GameColor.Judgment["JudgmentLine_W4"])
-								:stopeffect()
-							end;
-							self:visible(true):zoom(0.3)
-							self:GetChild("Color"):spin():effectmagnitude(0,0,-170)
-						else
-							self:visible(false)
-						end;
-					else
-						self:visible(false)
-					end;
-				else
-					self:visible(false)
-				end;
-			end;
-			Def.Sprite{
-				Name="Star",
-				Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/star"),
-				InitCommand=function(s) s:spin():effectmagnitude(0,0,-170) end,
-			},
-			Def.Sprite{
-				Name="Color",
-				Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/colorstar"),
-			},
-		};
-	};
+	}
 end
 
 return Def.ActorFrame{
@@ -347,8 +238,8 @@ return Def.ActorFrame{
 	SongUnchosenMessageCommand=function(s) 
 		s:sleep(0.2):queuecommand("Remove")
 	end,
-    t;
-    Arrows;
+	PlayerFrames,
+	Arrows,
 
 	Def.ActorFrame{
 		Name = "Group Label",

--- a/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
@@ -141,7 +141,7 @@ t[#t+1] = Def.ActorFrame{
     c.Score:visible(true)
     c.Grade:visible(true)
     
-    s:playcommand('SetGrade', { Highscore = score, Steps = steps })
+    s:playcommand('SetScore', { Stats = score, Steps = steps })
   end,
   Def.Sprite{
     Texture="Player 1x2";
@@ -158,21 +158,21 @@ t[#t+1] = Def.ActorFrame{
     Texture="Judge Inner",
     InitCommand=function(s) s:xy(230,5) end,
   };
-  ScoreAndGrade.GetGradeActor{
-    Big = true
-  }..{
+  ScoreAndGrade.CreateGradeActor{
     Name='Grade',
-    InitCommand=function(s)
-      s:xy(400,-30):zoom(0.2)
-      s:GetChild('FullCombo'):zoom(1.5)
+    Big = true,
+    InitCommand=function(self)
+      self:xy(400,-30):zoom(0.2)
+      self:GetChild('FullCombo'):zoom(1.5)
     end,
   },
-  ScoreAndGrade.GetScoreActorRolling{
-    Font = '_avenirnext lt pro bold/25px',
-    Load = 'RollingNumbersSongData',
-  }..{
+  ScoreAndGrade.CreateScoreRollingActor{
     Name='Score',
-    InitCommand=function(s) s:xy(400,15):zoom(0.8):strokecolor(Color.Black) end,
+    Font='_avenirnext lt pro bold/25px',
+    Load='RollingNumbersSongData',
+    InitCommand=function(self)
+      self:xy(400,15):zoom(0.8):strokecolor(Color.Black)
+    end,
   },
   Def.ActorFrame{
     InitCommand=function(s) s:xy(325,6):halign(1) end,

--- a/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
@@ -1,326 +1,236 @@
-local t = Def.ActorFrame{};
+local t = Def.ActorFrame{}
 local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local xPosPlayer = {
-  P1 = -320,
-  P2 = -20
+	P1 = -320,
+	P2 = -20,
 };
 
-function TopRecord(pn) --�^�ǳ̰��������Ӭ���
-	local SongOrCourse, StepsOrTrail;
-	local myScoreSet = {
-		["HasScore"] = 0;
-		["SongOrCourse"] =0;
-		["topscore"] = 0;
-		["topW1"]=0;
-		["topW2"]=0;
-		["topW3"]=0;
-		["topW4"]=0;
-		["topW5"]=0;
-		["topMiss"]=0;
-		["topOK"]=0;
-		["topEXScore"]=0;
-		["topMAXCombo"]=0;
-		["topDate"]=0;
-		};
+function GetSongScoreData(pn)
+	local data = {
+		HasScore = false,
+		Date     = nil,
+		Score    = 0,
+		EXScore  = 0,
+		MAXCombo = 0,
+		W1       = 0,
+		W2       = 0,
+		W3       = 0,
+		W4       = 0,
+		W5       = 0,
+		Miss     = 0,
+		OK       = 0,
+	}
 
+	local SongOrCourse, StepsOrTrail
 	if GAMESTATE:IsCourseMode() then
-		SongOrCourse = GAMESTATE:GetCurrentCourse();
-		StepsOrTrail = GAMESTATE:GetCurrentTrail(pn);
+		SongOrCourse = GAMESTATE:GetCurrentCourse()
+		StepsOrTrail = GAMESTATE:GetCurrentTrail(pn)
 	else
-		SongOrCourse = GAMESTATE:GetCurrentSong();
-		StepsOrTrail = GAMESTATE:GetCurrentSteps(pn);
-	end;
-
-	local profile, scorelist;
-
-	if SongOrCourse and StepsOrTrail then
-		local st = StepsOrTrail:GetStepsType();
-		local diff = StepsOrTrail:GetDifficulty();
-		local courseType = GAMESTATE:IsCourseMode() and SongOrCourse:GetCourseType() or nil;
-
-		if PROFILEMAN:IsPersistentProfile(pn) then
-			-- player profile
-			profile = PROFILEMAN:GetProfile(pn);
-		else
-			-- machine profile
-			profile = PROFILEMAN:GetMachineProfile();
-		end;
-
-		scorelist = profile:GetHighScoreList(SongOrCourse,StepsOrTrail);
-		assert(scorelist);
-		local scores = scorelist:GetHighScores();
-		assert(scores);
-		-- local topscore=0;
-		-- local topW1=0;
-		-- local topW2=0;
-		-- local topW3=0;
-		-- local topW4=0;
-		-- local topW5=0;
-		-- local topMiss=0;
-		-- local topOK=0;
-		-- local topEXScore=0;
-		-- local topMAXCombo=0;
-		if scores[1] then
-			myScoreSet["SongOrCourse"]=1;
-			myScoreSet["HasScore"] = 1;
-			myScoreSet["topscore"] = scores[1]:GetScore();
-			myScoreSet["topW1"]  = scores[1]:GetTapNoteScore("TapNoteScore_W1");
-			myScoreSet["topW2"]  = scores[1]:GetTapNoteScore("TapNoteScore_W2");
-			myScoreSet["topW3"]  = scores[1]:GetTapNoteScore("TapNoteScore_W3");
-			myScoreSet["topW4"]  = scores[1]:GetTapNoteScore("TapNoteScore_W4")+scores[1]:GetTapNoteScore("TapNoteScore_W5");
-			myScoreSet["topW5"]  = scores[1]:GetTapNoteScore("TapNoteScore_W5");
-			myScoreSet["topMiss"]  = scores[1]:GetHoldNoteScore("HoldNoteScore_LetGo")+scores[1]:GetTapNoteScore("TapNoteScore_Miss");
-			myScoreSet["topOK"]  = scores[1]:GetHoldNoteScore("HoldNoteScore_Held");
-			myScoreSet["topMAXCombo"]  = scores[1]:GetMaxCombo();
-			myScoreSet["topDate"]  = scores[1]:GetDate() ;
-			--myScoreSet["topEXScore"]  = scores[1]:GetTapNoteScore("TapNoteScore_W1")*3+scores[1]:GetTapNoteScore("TapNoteScore_W2")*2+scores[1]:GetTapNoteScore("TapNoteScore_W3")+scores[1]:GetHoldNoteScore("HoldNoteScore_Held")*3;
-			if (StepsOrTrail:GetRadarValues( pn ):GetValue( "RadarCategory_TapsAndHolds" ) >=0) then --If it is not a random course
-				if scores[1]:GetGrade() ~= "Grade_Failed" then
-					myScoreSet["topEXScore"] = scores[1]:GetTapNoteScore("TapNoteScore_W1")*3+scores[1]:GetTapNoteScore("TapNoteScore_W2")*2+scores[1]:GetTapNoteScore("TapNoteScore_W3")+scores[1]:GetHoldNoteScore("HoldNoteScore_Held")*3;
-				else
-					myScoreSet["topEXScore"] = (StepsOrTrail:GetRadarValues( pn ):GetValue( "RadarCategory_TapsAndHolds" )*3+StepsOrTrail:GetRadarValues( pn ):GetValue( "RadarCategory_Holds" )*3)*scores[1]:GetPercentDP();
-				end
-			else --If it is Random Course then the scores[1]:GetPercentDP() value will be -1
-				if scores[1]:GetGrade() ~= "Grade_Failed" then
-					myScoreSet["topEXScore"]  = scores[1]:GetTapNoteScore("TapNoteScore_W1")*3+scores[1]:GetTapNoteScore("TapNoteScore_W2")*2+scores[1]:GetTapNoteScore("TapNoteScore_W3")+scores[1]:GetHoldNoteScore("HoldNoteScore_Held")*3;
-				else
-					myScoreSet["topEXScore"]  = 0;
-				end
-			end
-			myScoreSet["topMAXCombo"]  = scores[1]:GetMaxCombo();
-			myScoreSet["topDate"]  = scores[1]:GetDate() ;
-		else
-			myScoreSet["SongOrCourse"]=1;
-			myScoreSet["HasScore"] = 0;
-		end;
-	else
-		myScoreSet["HasScore"] = 0;
-		myScoreSet["SongOrCourse"]=0;
-
+		SongOrCourse = GAMESTATE:GetCurrentSong()
+		StepsOrTrail = GAMESTATE:GetCurrentSteps(pn)
 	end
-	return myScoreSet;
+	if not (SongOrCourse and StepsOrTrail) then
+		return data
+	end
 
-end;
+	local profile
+	if PROFILEMAN:IsPersistentProfile(pn) then
+		profile = PROFILEMAN:GetProfile(pn)
+	else
+		profile = PROFILEMAN:GetMachineProfile()
+	end
+	
+	local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
+	local score = scores[1]
+	if not score then
+		return data
+	end
+	
+	data.HasScore  = true
+	data.Date     = score:GetDate() 
+	data.Score    = ScoreAndGrade.GetScore(score, StepsOrTrail, false)
+	data.EXScore  = ScoreAndGrade.GetScore(score, StepsOrTrail, true)
+	data.MAXCombo = score:GetMaxCombo()
+	data.W1       = score:GetTapNoteScore('TapNoteScore_W1')
+	data.W2       = score:GetTapNoteScore('TapNoteScore_W2')
+	data.W3       = score:GetTapNoteScore('TapNoteScore_W3')
+	data.W4       = score:GetTapNoteScore('TapNoteScore_W4')
+	data.Miss     = score:GetTapNoteScore('TapNoteScore_W5') + score:GetTapNoteScore('TapNoteScore_Miss') + score:GetHoldNoteScore('HoldNoteScore_LetGo')
+	data.OK       = score:GetHoldNoteScore('HoldNoteScore_Held')
+	
+	return data
+end
 
 for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
-t[#t+1] = Def.ActorFrame{
-  InitCommand=function(self)
-    local short = ToEnumShortString(pn)
-    self:x(xPosPlayer[short]):halign(0)
-  end;
-  CurrentSongChangedMessageCommand=function(s) s:queuecommand('Set') end,
-  CurrentTrailP1ChangedMessageCommand=function(s) s:queuecommand('Set') end,
-  CurrentStepsP1ChangedMessageCommand=function(s) s:queuecommand('Set') end,
-  CurrentCourseChangedMessageCommand=function(s) s:queuecommand('Set') end,
-  SetCommand=function(s)
-    local c = s:GetChildren()
-    
-    local song = GAMESTATE:GetCurrentSong()
-    local steps = GAMESTATE:GetCurrentSteps(pn)
-    if not (song and steps) then
-      c.Score:visible(false)
-      c.Grade:visible(false)
-      return
-    end
-    
-    local profile
-    if PROFILEMAN:IsPersistentProfile(pn) then
-      profile = PROFILEMAN:GetProfile(pn)
-    else
-      profile = PROFILEMAN:GetMachineProfile()
-    end
+	t[#t+1] = Def.ActorFrame{
+		InitCommand=function(self)
+			local short = ToEnumShortString(pn)
+			self:x(xPosPlayer[short]):halign(0)
+		end,
+		BeginCommand=function(s) s:playcommand('Set') end,
+		CurrentSongChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		['CurrentSteps'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		['CurrentTrail'..ToEnumShortString(pn)..'ChangedMessageCommand']=function(s) s:queuecommand('Set') end,
+		CurrentCourseChangedMessageCommand=function(s) s:queuecommand('Set') end,
+		SetCommand=function(s)
+			local c = s:GetChildren()
+			
+			local song = GAMESTATE:GetCurrentSong()
+			local steps = GAMESTATE:GetCurrentSteps(pn)
+			if not (song and steps) then
+				c.Score:visible(false)
+				c.Grade:visible(false)
+				return
+			end
+			
+			local profile
+			if PROFILEMAN:IsPersistentProfile(pn) then
+				profile = PROFILEMAN:GetProfile(pn)
+			else
+				profile = PROFILEMAN:GetMachineProfile()
+			end
 
-    local scores = profile:GetHighScoreList(song, steps):GetHighScores()
-    local score = scores[1]
-    if not score then
-      c.Score:visible(false)
-      c.Grade:visible(false)
-      return
-    end
-    c.Score:visible(true)
-    c.Grade:visible(true)
-    
-    s:playcommand('SetScore', { Stats = score, Steps = steps })
-  end,
-  Def.Sprite{
-    Texture="Player 1x2";
-    InitCommand=function(s) s:xy(260,-80):pause():setstate(0) end,
-    BeginCommand=function(self)
-      if pn == PLAYER_1 then
-        self:setstate(0)
-      else
-        self:setstate(1)
-      end;
-    end;
-  };
-  Def.Sprite{
-    Texture="Judge Inner",
-    InitCommand=function(s) s:xy(230,5) end,
-  };
-  ScoreAndGrade.CreateGradeActor{
-    Name='Grade',
-    Big = true,
-    InitCommand=function(self)
-      self:xy(400,-30):zoom(0.2)
-      self:GetChild('FullCombo'):zoom(1.5)
-    end,
-  },
-  ScoreAndGrade.CreateScoreRollingActor{
-    Name='Score',
-    Font='_avenirnext lt pro bold/25px',
-    Load='RollingNumbersSongData',
-    InitCommand=function(self)
-      self:xy(400,15):zoom(0.8):strokecolor(Color.Black)
-    end,
-  },
-  Def.ActorFrame{
-    InitCommand=function(s) s:xy(325,6):halign(1) end,
-    CurrentSongChangedMessageCommand=function(s) s:queuecommand("Set") end,
-    CurrentTrailP1ChangedMessageCommand=function(s) s:queuecommand("Set") end,
-    CurrentStepsP1ChangedMessageCommand=function(s) s:queuecommand("Set") end,
-    CurrentCourseChangedMessageCommand=function(s) s:queuecommand("Set") end,
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/25px";
-      InitCommand=function(s) s:xy(-65,-66):zoom(0.5) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        myScoreSet = TopRecord(pn);
-        local temp = myScoreSet["topDate"];
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            self:settext( temp);
-            self:diffusealpha(1);
-          else
-            self:diffusealpha(0);
-          end
-        else
-          self:diffusealpha(0);
-        end
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(-50):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topMAXCombo"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(-35):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topW1"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(-18):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topW2"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topW3"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(16):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topW4"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(32):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topOK"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-    Def.RollingNumbers{
-      File = THEME:GetPathF("","_avenirnext lt pro bold/20px");
-      InitCommand=function(s) s:halign(1):y(48):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        self:Load("RollingNumbersJudgment");
-        myScoreSet = TopRecord(pn)
-        if (myScoreSet["SongOrCourse"]==1) then
-          if (myScoreSet["HasScore"]==1) then
-            local topscore = myScoreSet["topMiss"];
-            self:targetnumber(topscore)
-          else
-            self:targetnumber(0);
-          end;
-        end;
-      end;
-    };
-  };
-};
+			local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+			local score = scores[1]
+			if not score then
+				c.Score:visible(false)
+				c.Grade:visible(false)
+				return
+			end
+			c.Score:visible(true)
+			c.Grade:visible(true)
+			
+			s:playcommand('SetScore', { Stats = score, Steps = steps })
+		end,
+		Def.Sprite{
+			Texture='Player 1x2',
+			InitCommand=function(s) s:xy(260,-80):pause():setstate(0) end,
+			BeginCommand=function(self)
+				if pn == PLAYER_1 then
+					self:setstate(0)
+				else
+					self:setstate(1)
+				end
+			end,
+		},
+		Def.Sprite{
+			Texture='Judge Inner',
+			InitCommand=function(s) s:xy(230,5) end,
+		},
+		ScoreAndGrade.CreateGradeActor{
+			Name='Grade',
+			Big=true,
+			InitCommand=function(self)
+				self:xy(400,-30):zoom(0.2)
+				self:GetChild('FullCombo'):zoom(1.5)
+			end,
+		},
+		ScoreAndGrade.CreateScoreRollingActor{
+			Name='Score',
+			Font='_avenirnext lt pro bold/25px',
+			Load='RollingNumbersSongData',
+			InitCommand=function(self)
+				self:xy(400,15):zoom(0.8):strokecolor(Color.Black)
+			end,
+		},
+		Def.ActorFrame{
+			InitCommand=function(s) s:xy(325,6):halign(1) end,
+			SetCommand=function(self)
+				local scoreData = GetSongScoreData(pn)
+				self:playcommand('SetScoreFromData', scoreData)
+			end,
+			Def.BitmapText{
+				Font='_avenirnext lt pro bold/25px';
+				InitCommand=function(s) s:xy(-65,-66):zoom(0.5) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:visible(false)
+						return
+					end
+					self:visible(true)
+					self:settext(data.Date)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(-50):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.MAXCombo)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px');
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(-35):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.W1)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(-18):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.W2)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.W3)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(16):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.W4)
+				end,
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(32):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.OK)
+				end
+			},
+			Def.RollingNumbers{
+				File = THEME:GetPathF('','_avenirnext lt pro bold/20px'),
+				InitCommand=function(s) s:Load('RollingNumbersJudgment'):halign(1):y(48):zoom(0.75) end,
+				SetScoreFromDataCommand=function(self, data)
+					if not data.HasScore then
+						self:targetnumber(0)
+						return
+					end
+					self:targetnumber(data.Miss)
+				end,
+			},
+		},
+	}
+end
 
-end;
-
-return t;
+return t

--- a/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/Types/Wheel/Pane.lua
@@ -133,7 +133,7 @@ t[#t+1] = Def.ActorFrame{
 
     local scores = profile:GetHighScoreList(song, steps):GetHighScores()
     local score = scores[1]
-    if not score or score:GetScore() == 0 then
+    if not score then
       c.Score:visible(false)
       c.Grade:visible(false)
       return

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
@@ -80,12 +80,10 @@ t[#t+1] = Def.ActorFrame{
                         end;
                     end;
                 else
-                    c.Text_score:settext("")
                     c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
                 end
             end
         else
-            c.Text_score:settext("")
             c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
         end
     end,

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
@@ -44,7 +44,7 @@ t[#t+1] = Def.ActorFrame{
                 assert(scores)
                 local score = scores[1]
                 
-                s:playcommand('SetGrade', { Highscore = score, Steps = steps })
+                s:playcommand('SetScore', { Stats = score, Steps = steps })
                 
                 local topscore = 0
                 if score then
@@ -98,12 +98,13 @@ t[#t+1] = Def.ActorFrame{
         Name="Text_name",
         InitCommand=function(s) s:y(-34):maxwidth(300/0.8):zoom(0.8) end,
     };
-    ScoreAndGrade.GetScoreActorRolling{
-        Font = '_avenirnext lt pro bold/25px',
-        Load = 'RollingNumbersSongData',
-    }..{
+    ScoreAndGrade.CreateScoreRollingActor{
         Name='Text_score',
-        InitCommand=function(s) s:xy(0,-6):zoom(0.9) end,
+        Font='_avenirnext lt pro bold/25px',
+        Load='RollingNumbersSongData',
+        InitCommand=function(self)
+            self:xy(0,-6):zoom(0.9)
+        end,
     },
     LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,1,"Player","Current",diff)..{
         InitCommand=function(s) s:xy(40,-6) end,

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/InfoPanel/default.lua
@@ -4,480 +4,487 @@ local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local ver = ""
 if ThemePrefs.Get("SV") == "onepointzero" then
-  ver = "1_"
+	ver = "1_"
 end
 
 local function XPOS(self,offset)
-    self:x(pn==PLAYER_1 and (SCREEN_LEFT+240)+offset or (SCREEN_RIGHT-240)+offset)
+	self:x(pn==PLAYER_1 and (SCREEN_LEFT+240)+offset or (SCREEN_RIGHT-240)+offset)
 end
 
 local yspacing = 32
 local keyset={}
 
 for i, pn in ipairs(GAMESTATE:GetHumanPlayers()) do
-    if not keyset[pn] then
-        keyset[pn] = false
-    end
+	if not keyset[pn] then
+		keyset[pn] = false
+	end
 end
 
 local function PlayerPanel()
-    local t = Def.ActorFrame{}
-    
-    t[#t+1] = Def.ActorFrame{
-        SetCommand=function(s)
-            local c = s:GetChildren()
-            
+	local t = Def.ActorFrame{}
+	
+	t[#t+1] = Def.ActorFrame{
+		SetCommand=function(s)
+			local c = s:GetChildren()
+			
 			local SongOrCourse, StepsOrTrail
-            if GAMESTATE:IsCourseMode() then
+			if GAMESTATE:IsCourseMode() then
 				SongOrCourse = GAMESTATE:GetCurrentCourse()
 				StepsOrTrail = GAMESTATE:GetCurrentTrail(pn)
 			else
 				SongOrCourse = GAMESTATE:GetCurrentSong()
 				StepsOrTrail = GAMESTATE:GetCurrentSteps(pn)
 			end
-            
-            if not (SongOrCourse and StepsOrTrail) then
-                c.Text_name:settext('')
-                c.Text_score:visible(false)
-                c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
-                return
-            end
-            
-            local profile
-            if PROFILEMAN:IsPersistentProfile(pn) then
-                profile = PROFILEMAN:GetProfile(pn)
-            else
-                profile = PROFILEMAN:GetMachineProfile()
-            end
-            local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
-            local score = scores[1]
-            
-            if not score then
-                c.Text_name:settext('')
-                c.Text_score:visible(false)
-                c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
-                return
-            end
-            c.Text_name:settext(score:GetName())
-            c.Text_score:visible(true)
-            s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
-            
-            local marvelous = score:GetTapNoteScore("TapNoteScore_W1")
-            local perfects = score:GetTapNoteScore("TapNoteScore_W2")
-            local greats = score:GetTapNoteScore("TapNoteScore_W3")
-            local goods = score:GetTapNoteScore("TapNoteScore_W4")
-            local oks = score:GetHoldNoteScore("HoldNoteScore_Held")
-            local misses = score:GetTapNoteScore("TapNoteScore_W5")+score:GetTapNoteScore("TapNoteScore_Miss")+score:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-            c.Text_judgments:settext(
-                marvelous .. '\n' ..
-                perfects .. '\n' ..
-                greats .. '\n' ..
-                goods .. '\n' ..
-                oks .. '\n' ..
-                misses
-            )
-        end,
-        Def.Sprite{
-            Name="Bar_underlay",
-            Texture="playerbacker",
-            InitCommand=function(s) s:y(-20) end,
-        };
-        Def.BitmapText{
-            Font="Common normal",
-            Text="";
-            Name="Text_name",
-            InitCommand=function(s) s:y(-34):maxwidth(300/0.8):zoom(0.8) end,
-        };
-        ScoreAndGrade.CreateScoreRollingActor{
-            Name='Text_score',
-            Font='_avenirnext lt pro bold/25px',
-            Load='RollingNumbersSongData',
-            InitCommand=function(self)
-                self:xy(0,-6):zoom(0.9)
-            end,
-        },
-        LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,1,"Player","Current",diff)..{
-            InitCommand=function(s) s:xy(40,-6) end,
-        },
-        Def.BitmapText{
-            Font="Common normal",
-            Name="Text_judgmenttitles",
-            InitCommand=function(s) s:zoom(0.9):halign(0):addx(-140):addy(80) end,
-            OnCommand=function(s) s:settext("Marvelous\nPerfect\nGreat\nGood\nOK\nMiss") end,
-        };
-        Def.BitmapText{
-            Font="Common normal",
-            Name="Text_judgments";
-            InitCommand=function(s) s:zoom(0.9):halign(1):addx(120):addy(80) end,
-        };
-    }
-    return t
+			
+			if not (SongOrCourse and StepsOrTrail) then
+				c.Text_name:settext('')
+				c.Text_score:visible(false)
+				c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
+				return
+			end
+			
+			local profile
+			if PROFILEMAN:IsPersistentProfile(pn) then
+				profile = PROFILEMAN:GetProfile(pn)
+			else
+				profile = PROFILEMAN:GetMachineProfile()
+			end
+			local scores = profile:GetHighScoreList(SongOrCourse, StepsOrTrail):GetHighScores()
+			local score = scores[1]
+			
+			if not score then
+				c.Text_name:settext('')
+				c.Text_score:visible(false)
+				c.Text_judgments:settext("0\n0\n0\n0\n0\n0")
+				return
+			end
+			c.Text_name:settext(score:GetName())
+			c.Text_score:visible(true)
+			s:playcommand('SetScore', { Stats = score, Steps = StepsOrTrail })
+			
+			local marvelous = score:GetTapNoteScore("TapNoteScore_W1")
+			local perfects = score:GetTapNoteScore("TapNoteScore_W2")
+			local greats = score:GetTapNoteScore("TapNoteScore_W3")
+			local goods = score:GetTapNoteScore("TapNoteScore_W4")
+			local oks = score:GetHoldNoteScore("HoldNoteScore_Held")
+			local misses = score:GetTapNoteScore("TapNoteScore_W5")+score:GetTapNoteScore("TapNoteScore_Miss")+score:GetTapNoteScore("TapNoteScore_CheckpointMiss")
+			c.Text_judgments:settext(
+				marvelous .. '\n' ..
+				perfects .. '\n' ..
+				greats .. '\n' ..
+				goods .. '\n' ..
+				oks .. '\n' ..
+				misses
+			)
+		end,
+		Def.Sprite{
+			Name="Bar_underlay",
+			Texture="playerbacker",
+			InitCommand=function(s) s:y(-20) end,
+		},
+		Def.BitmapText{
+			Font="Common normal",
+			Text="",
+			Name="Text_name",
+			InitCommand=function(s) s:y(-34):maxwidth(300/0.8):zoom(0.8) end,
+		},
+		ScoreAndGrade.CreateScoreRollingActor{
+			Name='Text_score',
+			Font='_avenirnext lt pro bold/25px',
+			Load='RollingNumbersSongData',
+			InitCommand=function(self)
+				self:xy(0,-6):zoom(0.9)
+			end,
+		},
+		LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,1,"Player","Current",diff)..{
+			InitCommand=function(s) s:xy(40,-6) end,
+		},
+		Def.BitmapText{
+			Font="Common normal",
+			Name="Text_judgmenttitles",
+			InitCommand=function(s) s:zoom(0.9):halign(0):addx(-140):addy(80) end,
+			OnCommand=function(s) s:settext("Marvelous\nPerfect\nGreat\nGood\nOK\nMiss") end,
+		},
+		Def.BitmapText{
+			Font="Common normal",
+			Name="Text_judgments",
+			InitCommand=function(s) s:zoom(0.9):halign(1):addx(120):addy(80) end,
+		},
+	}
+	return t
 end
 
-local difficulties = {"Difficulty_Beginner", "Difficulty_Easy", "Difficulty_Medium", "Difficulty_Hard", "Difficulty_Challenge", "Difficulty_Edit"}
-
-
+local difficulties = {
+	'Difficulty_Beginner',
+	'Difficulty_Easy',
+	'Difficulty_Medium',
+	'Difficulty_Hard',
+	'Difficulty_Challenge',
+	'Difficulty_Edit',
+}
 local function DifficultyPanel()
-    local t = Def.ActorFrame{};
-    for diff in ivalues(difficulties) do
-        t[#t+1] = Def.ActorFrame{
-            InitCommand=function(s) s:y((Difficulty:Reverse()[diff] * yspacing)) end,
-            SetCommand=function(s)
-                local c = s:GetChildren()
-                local song = GAMESTATE:GetCurrentSong() or GAMESTATE:GetCurrentCourse()
-                local bHasStepsTypeAndDifficulty = false;
-                local curDiff;
-                local steps;
-                if song then
-                    local st = GAMESTATE:GetCurrentStyle():GetStepsType()
-                    if not GAMESTATE:IsCourseMode() then
-                        bHasStepsTypeAndDifficulty = song:HasStepsTypeAndDifficulty(st, diff)
-                        steps = song:GetOneSteps(st,diff)
-                    else
-                        steps = GAMESTATE:GetCurrentTrail(pn)
-                    end
-                    if steps then
-                        if not GAMESTATE:IsCourseMode() then
-                            local meter = steps:GetMeter()
-                            c.Text_meter:settext(IsMeterDec(meter))
-                            c.Text_meter:visible(true)
-                        end
-                        c.Text_difficulty:settext(THEME:GetString("CustomDifficulty",ToEnumShortString(diff))):visible(true)
-                        c.Text_difficulty:diffuse(CustomDifficultyToColor(diff))
-                        local cursteps = GAMESTATE:GetCurrentSteps(pn) or GAMESTATE:GetCurrentTrail(player)
-                        if cursteps then
-                            curDiff = cursteps:GetDifficulty(pn)
-                            if ToEnumShortString(curDiff) == ToEnumShortString(diff) then
-                                c.Bar_underlay:diffuse(CustomDifficultyToColor(diff))
-                            else
-                                c.Bar_underlay:diffuse(Color.White)
-                            end
-                        end
-                        scorelist = PROFILEMAN:GetProfile(pn):GetHighScoreList(song,steps)
-                        assert(scorelist)
-                        local scores = scorelist:GetHighScores()
-                        assert(scores)
-                        local topscore=0
-                        local temp=#scores
-                        if scores[1] then
-                            if ThemePrefs.Get("ConvertScoresAndGrades") then
-                                topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-                            else
-                                topscore = scores[1]:GetScore()
-                            end
-                            RStats = scores[1];
-                        end
-                        assert(topscore)
-                        if topscore ~= 0 then
-                            c.Text_score:settext(commify(topscore))
-                        else
-                            c.Text_score:settext("")
-                        end
-                    else
-                        c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
-                        c.Text_meter:settext("")  
-                        c.Text_difficulty:settext("")
-                        c.Text_score:settext("")
-                    end
-                else
-                    c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
-                    c.Text_meter:settext("")
-                    c.Text_difficulty:settext("")
-                    c.Text_score:settext("")
-                end
-            end;
-            Def.ActorFrame{
-                Name="Bar_underlay";
-                Def.Quad{
-                    InitCommand=function(s) s:setsize(312,26):faderight(0.75):diffusealpha(0.5) end,
-                };
-                Def.Quad{
-                    InitCommand=function(s) s:y(-12):setsize(312,2):faderight(0.5):diffusealpha(0.5) end,
-                };
-            };
-            Def.BitmapText{
-                Font="_avenirnext lt pro bold/25px",
-                Name="Text_meter";
-                InitCommand=function(s) s:x(-6):strokecolor(Alpha(Color.Black,0.5)) end,
-            };
-            Def.BitmapText{
-                Font="_avenirnext lt pro bold/20px",
-                Name="Text_difficulty",
-                InitCommand=function(s) s:x(-150):halign(0):strokecolor(Alpha(Color.Black,0.5)) end,
-            };
-            Def.BitmapText{
-                Name="Text_score",
-                Font="_avenirnext lt pro bold/20px",
-                InitCommand=function(s) s:x(120):halign(1):diffuse(Color.White):strokecolor(Color.Black) end,
-            };
-            LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,1,"Player","One",diff)..{
-                InitCommand=function(s) s:x(146) end,
-            }
-        };
-    end
-    return t
+	local t = Def.ActorFrame{}
+	for diff in ivalues(difficulties) do
+		t[#t+1] = Def.ActorFrame{
+			InitCommand=function(s) s:y((Difficulty:Reverse()[diff] * yspacing)) end,
+			SetCommand=function(s)
+				local c = s:GetChildren()
+				local song = GAMESTATE:GetCurrentSong() or GAMESTATE:GetCurrentCourse()
+				local bHasStepsTypeAndDifficulty = false
+				local curDiff
+				local steps
+				if song then
+					local st = GAMESTATE:GetCurrentStyle():GetStepsType()
+					if not GAMESTATE:IsCourseMode() then
+						bHasStepsTypeAndDifficulty = song:HasStepsTypeAndDifficulty(st, diff)
+						steps = song:GetOneSteps(st,diff)
+					else
+						steps = GAMESTATE:GetCurrentTrail(pn)
+					end
+					if steps then
+						if not GAMESTATE:IsCourseMode() then
+							local meter = steps:GetMeter()
+							c.Text_meter:settext(IsMeterDec(meter))
+							c.Text_meter:visible(true)
+						end
+						c.Text_difficulty:settext(THEME:GetString("CustomDifficulty",ToEnumShortString(diff))):visible(true)
+						c.Text_difficulty:diffuse(CustomDifficultyToColor(diff))
+						local cursteps = GAMESTATE:GetCurrentSteps(pn) or GAMESTATE:GetCurrentTrail(player)
+						if cursteps then
+							curDiff = cursteps:GetDifficulty(pn)
+							if ToEnumShortString(curDiff) == ToEnumShortString(diff) then
+								c.Bar_underlay:diffuse(CustomDifficultyToColor(diff))
+							else
+								c.Bar_underlay:diffuse(Color.White)
+							end
+						end
+						scorelist = PROFILEMAN:GetProfile(pn):GetHighScoreList(song,steps)
+						assert(scorelist)
+						local scores = scorelist:GetHighScores()
+						assert(scores)
+						local topscore=0
+						local temp=#scores
+						if scores[1] then
+							if ThemePrefs.Get("ConvertScoresAndGrades") then
+								topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
+							else
+								topscore = scores[1]:GetScore()
+							end
+							RStats = scores[1]
+						end
+						assert(topscore)
+						if topscore ~= 0 then
+							c.Text_score:settext(commify(topscore))
+						else
+							c.Text_score:settext("")
+						end
+					else
+						c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
+						c.Text_meter:settext("")  
+						c.Text_difficulty:settext("")
+						c.Text_score:settext("")
+					end
+				else
+					c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
+					c.Text_meter:settext("")
+					c.Text_difficulty:settext("")
+					c.Text_score:settext("")
+				end
+			end,
+			Def.ActorFrame{
+				Name="Bar_underlay",
+				Def.Quad{
+					InitCommand=function(s) s:setsize(312,26):faderight(0.75):diffusealpha(0.5) end,
+				},
+				Def.Quad{
+					InitCommand=function(s) s:y(-12):setsize(312,2):faderight(0.5):diffusealpha(0.5) end,
+				},
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/25px",
+				Name="Text_meter",
+				InitCommand=function(s) s:x(-6):strokecolor(Alpha(Color.Black,0.5)) end,
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/20px",
+				Name="Text_difficulty",
+				InitCommand=function(s) s:x(-150):halign(0):strokecolor(Alpha(Color.Black,0.5)) end,
+			},
+			Def.BitmapText{
+				Name="Text_score",
+				Font="_avenirnext lt pro bold/20px",
+				InitCommand=function(s) s:x(120):halign(1):diffuse(Color.White):strokecolor(Color.Black) end,
+			},
+			LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,1,"Player","One",diff)..{
+				InitCommand=function(s) s:x(146) end,
+			},
+		}
+	end
+	return t
 end
 
 local function RivalsPanel(rival)
-    local t = Def.ActorFrame{};
-    local rivals = {1,2,3,4,5}
-    for rival in ivalues(rivals) do
-        t[#t+1] = Def.ActorFrame{
-            InitCommand=function(s) s:y((rivals[rival]*yspacing)-yspacing) end,
-            SetCommand=function(s)
-                local c = s:GetChildren();
-                local song = GAMESTATE:GetCurrentSong()
-                if song then
-                    local steps = GAMESTATE:GetCurrentSteps(pn)
-                    if steps then
-                        c.Bar_underlay:visible(true)
-                        if rival == 1 then
-                            c.Bar_place:diffuse(color("#3cbbf6"))
-                        elseif rival == 2 then
-                            c.Bar_place:diffuse(color("#d6d7d4"))
-                        elseif rival == 3 then
-                            c.Bar_place:diffuse(color("#f6cc40"))
-                        else
-                            c.Bar_place:diffuse(color("#f22133"))
-                        end
-                    end
-                    local profile = PROFILEMAN:GetMachineProfile();
-                    scorelist = PROFILEMAN:GetMachineProfile():GetHighScoreList(song,steps)
-                    local scores = scorelist:GetHighScores()
-                    local topscore = 0
-                    if scores[rival] then
-                        if ThemePrefs.Get("ConvertScoresAndGrades") then
-                            topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[rival])
-                        else
-                            topscore = scores[rival]:GetScore()
-                        end
-                    end
-                    RStats = scores[1];
-                    if topscore ~= 0 then
-                        c.Bar_underlay:diffuse(Color.White)
-                        c.Text_score:settext(commify(topscore))
-                        if scores[rival]:GetName() ~= nil then
-                            if scores[rival]:GetName() == "" then
-                                c.Text_name:settext("NO NAME")
-                            else
-                                c.Text_name:settext(scores[rival]:GetName())
-                            end
-                        else
-                            c.Text_name:settext("STEP")
-                        end
-                    else
-                        c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
-                        c.Text_score:settext("")
-                        c.Text_name:settext("")
-                    end
-                else
-                    c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
-                    c.Text_score:settext("")
-                    c.Text_name:settext("")
-                end
-            end,
-            Def.ActorFrame{
-                Name="Bar_underlay";
-                Def.Quad{
-                    InitCommand=function(s) s:setsize(312,26):faderight(0.75):diffusealpha(0.5) end,
-                };
-                Def.Quad{
-                    InitCommand=function(s) s:y(-12):setsize(312,2):faderight(0.5):diffusealpha(0.5) end,
-                };
-            };
-            Def.Quad{
-                Name="Bar_place",
-                InitCommand=function(s) s:x(-140):setsize(20,20) end,
-            };
-            Def.BitmapText{
-                Font="_avenirnext lt pro bold/25px",
-                Name="Text_place";
-                Text=rival;
-                InitCommand=function(s) s:x(-140):strokecolor(Alpha(Color.Black,0.5)):zoom(0.7) end,
-            };
-            Def.BitmapText{
-                Name="Text_name",
-                Font="_avenirnext lt pro bold/20px",
-                InitCommand=function(s) s:x(-120):halign(0):diffuse(Color.White):strokecolor(Color.Black) end,
-            };
-            Def.BitmapText{
-                Name="Text_score",
-                Font="_avenirnext lt pro bold/20px",
-                InitCommand=function(s) s:x(120):halign(1):diffuse(Color.White):strokecolor(Color.Black) end,
-            };
-            LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,rival,"Machine","Current",diff)..{
-                InitCommand=function(s) s:x(146) end,
-            }
-        }
-    end
-    return t
+	local t = Def.ActorFrame{}
+	local rivals = {1,2,3,4,5}
+	for rival in ivalues(rivals) do
+		t[#t+1] = Def.ActorFrame{
+			InitCommand=function(s) s:y((rivals[rival]*yspacing)-yspacing) end,
+			SetCommand=function(s)
+				local c = s:GetChildren()
+				local song = GAMESTATE:GetCurrentSong()
+				if song then
+					local steps = GAMESTATE:GetCurrentSteps(pn)
+					if steps then
+						c.Bar_underlay:visible(true)
+						if rival == 1 then
+							c.Bar_place:diffuse(color("#3cbbf6"))
+						elseif rival == 2 then
+							c.Bar_place:diffuse(color("#d6d7d4"))
+						elseif rival == 3 then
+							c.Bar_place:diffuse(color("#f6cc40"))
+						else
+							c.Bar_place:diffuse(color("#f22133"))
+						end
+					end
+					local profile = PROFILEMAN:GetMachineProfile()
+					scorelist = PROFILEMAN:GetMachineProfile():GetHighScoreList(song,steps)
+					local scores = scorelist:GetHighScores()
+					local topscore = 0
+					if scores[rival] then
+						if ThemePrefs.Get("ConvertScoresAndGrades") then
+							topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[rival])
+						else
+							topscore = scores[rival]:GetScore()
+						end
+					end
+					RStats = scores[1]
+					if topscore ~= 0 then
+						c.Bar_underlay:diffuse(Color.White)
+						c.Text_score:settext(commify(topscore))
+						if scores[rival]:GetName() ~= nil then
+							if scores[rival]:GetName() == "" then
+								c.Text_name:settext("NO NAME")
+							else
+								c.Text_name:settext(scores[rival]:GetName())
+							end
+						else
+							c.Text_name:settext("STEP")
+						end
+					else
+						c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
+						c.Text_score:settext("")
+						c.Text_name:settext("")
+					end
+				else
+					c.Bar_underlay:diffuse(Alpha(Color.White,0.2))
+					c.Text_score:settext("")
+					c.Text_name:settext("")
+				end
+			end,
+			Def.ActorFrame{
+				Name="Bar_underlay",
+				Def.Quad{
+					InitCommand=function(s) s:setsize(312,26):faderight(0.75):diffusealpha(0.5) end,
+				},
+				Def.Quad{
+					InitCommand=function(s) s:y(-12):setsize(312,2):faderight(0.5):diffusealpha(0.5) end,
+				},
+			},
+			Def.Quad{
+				Name="Bar_place",
+				InitCommand=function(s) s:x(-140):setsize(20,20) end,
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/25px",
+				Name="Text_place",
+				Text=rival,
+				InitCommand=function(s) s:x(-140):strokecolor(Alpha(Color.Black,0.5)):zoom(0.7) end,
+			},
+			Def.BitmapText{
+				Name="Text_name",
+				Font="_avenirnext lt pro bold/20px",
+				InitCommand=function(s) s:x(-120):halign(0):diffuse(Color.White):strokecolor(Color.Black) end,
+			},
+			Def.BitmapText{
+				Name="Text_score",
+				Font="_avenirnext lt pro bold/20px",
+				InitCommand=function(s) s:x(120):halign(1):diffuse(Color.White):strokecolor(Color.Black) end,
+			},
+			LoadActor(THEME:GetPathG("","myMusicWheel/default.lua"),pn,rival,"Machine","Current",diff)..{
+				InitCommand=function(s) s:x(146) end,
+			}
+		}
+	end
+	return t
 end
 
 local function RadarPanel()
-    local GR = {
-        {-1,-122, "Stream"}, --STREAM
-        {-120,-43, "Voltage"}, --VOLTAGE
-        {-108,72, "Air"}, --AIR
-        {108,72, "Freeze"}, --FREEZE
-        {120,-43, "Chaos"}, --CHAOS
-    };
-    local t = Def.ActorFrame{};
-    t[#t+1] = Def.ActorFrame{
-        Def.ActorFrame{
-            Name="Radar",
-            Def.Sprite{
-                Texture=THEME:GetPathG("","_shared/Radar/"..ver.."GrooveRadar base.png"),
-            };
-            Def.Sprite{
-                Texture=THEME:GetPathG("","_shared/Radar/sweep.png"),
-                InitCommand = function(s) s:zoom(1.35):spin():effectmagnitude(0,0,100) end,
-            };
-            Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25));
-        };
-    };
-    for i,v in ipairs(GR) do
-        t[#t+1] = Def.ActorFrame{
-            InitCommand=function(s)
-                s:xy(v[1],v[2])
-            end;
-            Def.Sprite{
-                Texture=THEME:GetPathG("","_shared/Radar/"..ver.."RLabels"),
-                OnCommand=function(s) s:animate(0):setstate(i-1) end,
-            };
-            Def.BitmapText{
-                Font="_avenirnext lt pro bold/20px";
-                SetCommand=function(s)
-                    local song = GAMESTATE:GetCurrentSong();
-                    if song then
-                        local steps = GAMESTATE:GetCurrentSteps(pn)
-                        local value = lookup_ddr_radar_values(song, steps, pn)[i]
-                        s:settext(math.floor(value*100+0.5))
-                    else
-                        s:settext("")
-                    end
-                    s:strokecolor(color("#1f1f1f")):y(28)
-                end,
-            };
-        };
-    end
-    return t
+	local GR = {
+		{-1,-122, "Stream"}, --STREAM
+		{-120,-43, "Voltage"}, --VOLTAGE
+		{-108,72, "Air"}, --AIR
+		{108,72, "Freeze"}, --FREEZE
+		{120,-43, "Chaos"}, --CHAOS
+	}
+	local t = Def.ActorFrame{}
+	t[#t+1] = Def.ActorFrame{
+		Def.ActorFrame{
+			Name="Radar",
+			Def.Sprite{
+				Texture=THEME:GetPathG("","_shared/Radar/"..ver.."GrooveRadar base.png"),
+			},
+			Def.Sprite{
+				Texture=THEME:GetPathG("","_shared/Radar/sweep.png"),
+				InitCommand = function(s) s:zoom(1.35):spin():effectmagnitude(0,0,100) end,
+			},
+			Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25)),
+		}
+	}
+	for i,v in ipairs(GR) do
+		t[#t+1] = Def.ActorFrame{
+			InitCommand=function(s)
+				s:xy(v[1],v[2])
+			end,
+			Def.Sprite{
+				Texture=THEME:GetPathG("","_shared/Radar/"..ver.."RLabels"),
+				OnCommand=function(s) s:animate(0):setstate(i-1) end,
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/20px",
+				SetCommand=function(s)
+					local song = GAMESTATE:GetCurrentSong()
+					if song then
+						local steps = GAMESTATE:GetCurrentSteps(pn)
+						local value = lookup_ddr_radar_values(song, steps, pn)[i]
+						s:settext(math.floor(value*100+0.5))
+					else
+						s:settext("")
+					end
+					s:strokecolor(color("#1f1f1f")):y(28)
+				end,
+			}
+		}
+	end
+	return t
 end
 
 local function PlayerInfo(pn)
-    local t = Def.ActorFrame{};
-    t[#t+1] = PlayerPanel()..{
-        InitCommand=function(s) s:valign(1):y(-20) end
-    };
-    return t
+	return Def.ActorFrame{
+		PlayerPanel()..{
+			InitCommand=function(s) s:valign(1):y(-20) end
+		}
+	}
 end
 
 local function Scroller(pn)
-    local t = Def.ActorFrame{};
-    t[#t+1] = Def.ActorScroller{
-        Name="ScrollerMain",
-        NumItemsToDraw=1,
-        SecondsPerItem=0.1,
-        OnCommand=function(s)
-            s:SetDestinationItem(0):SetFastCatchup(true)
-            :SetMask(320,20):fov(60):zwrite(true):draworder(8):z(8)
-        end,
-        TransformFunction=function(s,o,i,n)
-            s:x(math.floor(o*(10))):diffusealpha(1-math.abs(o))
-        end,
-        CodeMessageCommand=function(s,p)
-            local DI = s:GetCurrentItem();
-            if p.PlayerNumber == pn and keyset[pn] then
-                if p.Name=="PaneLeft" then
-                    if DI>0 then
-                        s:SetDestinationItem(DI-1)
-                        SOUND:PlayOnce(THEME:GetPathS("","MusicWheel expand"))
-                    end
-                end
-                if p.Name=="PaneRight" then
-                    if DI<2 then
-                        s:SetDestinationItem(DI+1)
-                        SOUND:PlayOnce(THEME:GetPathS("","MusicWheel expand"))
-                    end
-                end
-            end
-        end,
-        Def.ActorFrame{
-            Name="ScrollerItem1";
-            DifficultyPanel()..{ InitCommand=function(s) s:y(-260) end,};
-            Def.BitmapText{
-                Font="_stagetext",
-                Text="DIFFICULTY INFORMATION",
-                Name="Header",
-                InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
-            };
-        };
-        Def.ActorFrame{
-            Name="ScrollerItem2";
-            RadarPanel()..{
-                InitCommand=function(s) s:y(-165):zoom(0.8) end,
-            },
-            Def.BitmapText{
-                Font="_stagetext",
-                Text="RADAR INFORMATION",
-                Name="Header",
-                InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
-            };
-        };
-        -- scores
-	    Def.ActorFrame{
-		    Name="ScrollerItem3";
-		    RivalsPanel()..{
-		        InitCommand=function(s) s:y(-260) end,
-            };
-            Def.BitmapText{
-                Font="_stagetext",
-                Text="RIVAL INFORMATION",
-                Name="Header",
-                InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
-            };
-	    };
-    };
-    return t
+	local t = Def.ActorFrame{}
+	t[#t+1] = Def.ActorScroller{
+		Name="ScrollerMain",
+		NumItemsToDraw=1,
+		SecondsPerItem=0.1,
+		OnCommand=function(s)
+			s:SetDestinationItem(0):SetFastCatchup(true)
+			:SetMask(320,20):fov(60):zwrite(true):draworder(8):z(8)
+		end,
+		TransformFunction=function(s,o,i,n)
+			s:x(math.floor(o*(10))):diffusealpha(1-math.abs(o))
+		end,
+		CodeMessageCommand=function(s,p)
+			local DI = s:GetCurrentItem()
+			if p.PlayerNumber == pn and keyset[pn] then
+				if p.Name=="PaneLeft" then
+					if DI>0 then
+						s:SetDestinationItem(DI-1)
+						SOUND:PlayOnce(THEME:GetPathS("","MusicWheel expand"))
+					end
+				end
+				if p.Name=="PaneRight" then
+					if DI<2 then
+						s:SetDestinationItem(DI+1)
+						SOUND:PlayOnce(THEME:GetPathS("","MusicWheel expand"))
+					end
+				end
+			end
+		end,
+		Def.ActorFrame{
+			Name="ScrollerItem1",
+			DifficultyPanel()..{
+				InitCommand=function(s) s:y(-260) end
+			},
+			Def.BitmapText{
+				Font="_stagetext",
+				Text="DIFFICULTY INFORMATION",
+				Name="Header",
+				InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
+			},
+		},
+		Def.ActorFrame{
+			Name="ScrollerItem2",
+			RadarPanel()..{
+				InitCommand=function(s) s:y(-165):zoom(0.8) end,
+			},
+			Def.BitmapText{
+				Font="_stagetext",
+				Text="RADAR INFORMATION",
+				Name="Header",
+				InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
+			},
+		},
+		-- scores
+		Def.ActorFrame{
+			Name="ScrollerItem3",
+			RivalsPanel()..{
+				InitCommand=function(s) s:y(-260) end,
+			},
+			Def.BitmapText{
+				Font="_stagetext",
+				Text="RIVAL INFORMATION",
+				Name="Header",
+				InitCommand=function(s) s:zoom(0.7):y(-290):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
+			},
+		},
+	}
+	return t
 end
 
 local t = Def.ActorFrame{
-    InitCommand=function(s,p) XPOS(s,0) s:visible(false)
-    end,
-    BeginCommand=function(s) s:playcommand("Set") end,
-    OffCommand=function(s) s:sleep(0.5):decelerate(0.3):addx(pn==PLAYER_1 and -500 or 500) end,
-    CurrentSongChangedMessageCommand=function(s,p) s:queuecommand("Set") end,
-    CodeMessageCommand=function(s,p)
-        
-        if p.PlayerNumber == pn then
-            if p.Name == "OpenPanes1" or p.Name == "OpenPanesEFUp" then
-                if keyset[pn] == false then
-                    keyset[pn] = true
-                else
-                    keyset[pn] = false
-                end
-                s:visible(keyset[pn])
-                SOUND:PlayOnce(THEME:GetPathS("MusicWheel","expand"))
-            end
-        end
-    end,
-    ["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s,p) s:queuecommand("Set") end,
-    ["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s,p) s:queuecommand("Set") end,
-    Def.Sprite{
-        Texture="backer.png",
-    };
-    PlayerInfo(pn)..{
-        InitCommand=function(s) s:addy(90) end,
-    };
-    Scroller(pn)..{
-        InitCommand=function(s) s:addy(90) end,
-    };
-    Def.BitmapText{
-        Font="_stagetext",
-        Text="[PRESS ARROW PANELS TO CHANGE WINDOWS]",
-        InitCommand=function(s) s:zoom(0.5):y(240):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
-    };
-};
+	InitCommand=function(s,p) XPOS(s,0) s:visible(false)
+	end,
+	BeginCommand=function(s) s:playcommand("Set") end,
+	OffCommand=function(s) s:sleep(0.5):decelerate(0.3):addx(pn==PLAYER_1 and -500 or 500) end,
+	CurrentSongChangedMessageCommand=function(s,p) s:queuecommand("Set") end,
+	CodeMessageCommand=function(s,p)
+		
+		if p.PlayerNumber == pn then
+			if p.Name == "OpenPanes1" or p.Name == "OpenPanesEFUp" then
+				if keyset[pn] == false then
+					keyset[pn] = true
+				else
+					keyset[pn] = false
+				end
+				s:visible(keyset[pn])
+				SOUND:PlayOnce(THEME:GetPathS("MusicWheel","expand"))
+			end
+		end
+	end,
+	["CurrentSteps"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s,p) s:queuecommand("Set") end,
+	["CurrentTrail"..ToEnumShortString(pn).."ChangedMessageCommand"]=function(s,p) s:queuecommand("Set") end,
+	Def.Sprite{
+		Texture="backer.png",
+	},
+	PlayerInfo(pn)..{
+		InitCommand=function(s) s:addy(90) end,
+	},
+	Scroller(pn)..{
+		InitCommand=function(s) s:addy(90) end,
+	},
+	Def.BitmapText{
+		Font="_stagetext",
+		Text="[PRESS ARROW PANELS TO CHANGE WINDOWS]",
+		InitCommand=function(s) s:zoom(0.5):y(240):DiffuseAndStroke(color("#dff0ff"),color("0,0.7,1,0.5")) end,
+	},
+}
 
 
 
-return t;
+return t

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
@@ -1,25 +1,42 @@
 local pn = ...
 local yspacing = 32
 local DiffList = Def.ActorFrame{};
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local function DrawDiffListItem(diff)
   local DifficultyListItem = Def.ActorFrame{
     InitCommand=function(s)
       s:y(Difficulty:Reverse()[diff] * yspacing)
     end,
-    SetCommand=function(self)
-      local st=GAMESTATE:GetCurrentStyle():GetStepsType()
-      local song=GAMESTATE:GetCurrentSong()
-      if song then
-        if song:HasStepsTypeAndDifficulty( st, diff ) then
-          local steps = song:GetOneSteps( st, diff )
-          self:diffusealpha(1)
-        else
-          self:diffusealpha(0.5)
-        end
+    SetCommand=function(s)      
+      local c = s:GetChildren()
+      
+      local song = GAMESTATE:GetCurrentSong()
+      local stepType = GAMESTATE:GetCurrentStyle():GetStepsType()
+      local steps = song:GetOneSteps(stepType, diff)
+      if not (song and steps) then
+        s:diffusealpha(0.5)
+        c.Score:visible(false)
+        c.GradeFrame:visible(false)
+        return
+      end
+      s:diffusealpha(1)
+      
+      local profile
+      if PROFILEMAN:IsPersistentProfile(pn) then
+        profile = PROFILEMAN:GetProfile(pn)
       else
-        self:diffusealpha(0.5)
+        profile = PROFILEMAN:GetMachineProfile()
       end;
+      local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+      local score = scores[1]
+      if not score then
+        c.Score:visible(false)
+        c.GradeFrame:visible(false)
+        return
+      end
+      
+      s:playcommand('SetGrade', { Highscore = score, Steps = steps })
     end;
 
     Def.Quad{
@@ -52,170 +69,18 @@ local function DrawDiffListItem(diff)
         end;
       end;
     };
-
-    Def.BitmapText{
-      Font="_avenirnext lt pro bold/20px",
-      Name="Score";
-      InitCommand=function(s) s:draworder(5):x(pn==pn_2 and -69 or 69) end,
-      SetCommand=function(self)
-        self:settext("")
-
-        local st=GAMESTATE:GetCurrentStyle():GetStepsType()
-        local song=GAMESTATE:GetCurrentSong()
-        if song then
-          if song:HasStepsTypeAndDifficulty(st,diff) then
-            local steps = song:GetOneSteps(st,diff)
-
-            if PROFILEMAN:IsPersistentProfile(pn) then
-              profile = PROFILEMAN:GetProfile(pn)
-            else
-              profile = PROFILEMAN:GetMachineProfile()
-            end;
-
-            scorelist = profile:GetHighScoreList(song,steps)
-            local scores = scorelist:GetHighScores()
-            local topscore = 0
-
-            if scores[1] then
-              if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-                topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-              else
-                topscore = scores[1]:GetScore()
-              end
-            end;
-
-            self:strokecolor(Color.Black)
-            self:diffusealpha(1)
-
-            if topscore ~= 0 then
-                self:settext(commify(topscore))
-            end;
-          end;
-        end;
-      end;
-    };
-    Def.ActorFrame{
+    
+    ScoreAndGrade.GetScoreActor{}..{
+      Name='Score',
+      InitCommand=function(s) s:draworder(5):x(pn==pn_2 and -69 or 69):strokecolor(Color.Black) end,
+    },
+    ScoreAndGrade.GetGradeActor{
+      AlternativeFC = true,
+    }..{
+      Name='GradeFrame',
       InitCommand=function(s) s:x(pn==pn_2 and -148 or 140) end,
-    Def.Sprite{
-      Texture=THEME:GetPathG("Player","Badge FullCombo"),
-        InitCommand=function(s) s:shadowlength(1):zoom(0):draworder(5):xy(18,4):diffusealpha(0.8) end,
-        OffCommand=function(s) s:decelerate(0.05):diffusealpha(0) end,
-        SetCommand=function(self)
-          local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-          local song=GAMESTATE:GetCurrentSong();
-          local course = GAMESTATE:GetCurrentCourse();
-          if song then
-            if song:HasStepsTypeAndDifficulty(st,diff) then
-              local steps = song:GetOneSteps( st, diff );
-              if PROFILEMAN:IsPersistentProfile(pn) then
-                profile = PROFILEMAN:GetProfile(pn);
-              else
-                profile = PROFILEMAN:GetMachineProfile();
-              end;
-              scorelist = profile:GetHighScoreList(song,steps);
-              assert(scorelist);
-              local scores = scorelist:GetHighScores();
-              assert(scores);
-              local topscore;
-              if scores[1] then
-                topscore = scores[1];
-                assert(topscore);
-                local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-                local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-                local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-                local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-                local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-                if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-                  if (greats+perfects) == 0 then
-                    self:diffuse(GameColor.Judgment["JudgmentLine_W1"]);
-                    self:glowblink();
-                    self:effectperiod(0.20);
-                  elseif greats == 0 then
-                    self:diffuse(GameColor.Judgment["JudgmentLine_W2"]);
-                    self:glowshift();
-                  elseif (misses+boos+goods) == 0 then
-                    self:diffuse(GameColor.Judgment["JudgmentLine_W3"]);
-                    self:stopeffect();
-                  elseif (misses+boos) == 0 then
-                    self:diffuse(GameColor.Judgment["JudgmentLine_W4"]);
-                    self:stopeffect();
-                  end;
-                  self:visible(true)
-                  self:zoom(0.5);
-                else
-                  self:visible(false)
-                end;
-              else
-                self:visible(false)
-              end;
-            else
-              self:visible(false)
-            end;
-          else
-            self:visible(false)
-          end;
-        end
-      };
-      Def.Quad{
-        Name="Grade";
-      InitCommand=function(s) s:draworder(5):visible(false) end,
-      SetCommand=function(self)
-        local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-        local song=GAMESTATE:GetCurrentSong();
-        if song then
-          if song:HasStepsTypeAndDifficulty(st,diff) then
-            local steps = song:GetOneSteps(st, diff)
-            if PROFILEMAN:IsPersistentProfile(pn) then
-              profile = PROFILEMAN:GetProfile(pn)
-            else
-              profile = PROFILEMAN:GetMachineProfile()
-            end
-  
-            scorelist = profile:GetHighScoreList(song,steps)
-            local scores = scorelist:GetHighScores()
-  
-            local topscore=0
-            if scores[1] then
-              if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-                topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-              else
-                topscore = scores[1]:GetScore()
-              end
-            end
-  
-            local topgrade
-            if scores[1] then
-              topgrade = scores[1]:GetGrade();
-              assert(topgrade)
-              local tier;
-              if ThemePrefs.Get("ConvertScoresAndGrades") == true then
-                tier = SN2Grading.ScoreToGrade(topscore, diff)
-              else
-                tier = topgrade
-              end
-              if scores[1]:GetScore()>1  then
-                if topgrade == 'Grade_Failed' then
-                  self:LoadBackground(THEME:GetPathG("","myMusicWheel/GradeDisplayEval Failed"));
-                else
-                  self:LoadBackground(THEME:GetPathG("myMusicWheel/GradeDisplayEval",ToEnumShortString(tier)));
-                end;
-                self:visible(true)
-              else
-                self:visible(false)
-              end;
-            else
-              self:visible(false)
-            end;
-          else
-            self:visible(false)
-          end;
-        else
-          self:visible(false)
-        end;
-      end;
-      };
-    };
+    }
+    
   };
   return DifficultyListItem
 end

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
@@ -36,7 +36,7 @@ local function DrawDiffListItem(diff)
         return
       end
       
-      s:playcommand('SetGrade', { Highscore = score, Steps = steps })
+      s:playcommand('SetScore', { Stats = score, Steps = steps })
     end;
 
     Def.Quad{
@@ -70,15 +70,18 @@ local function DrawDiffListItem(diff)
       end;
     };
     
-    ScoreAndGrade.GetScoreActor{}..{
+    ScoreAndGrade.CreateScoreActor{
       Name='Score',
-      InitCommand=function(s) s:draworder(5):x(pn==pn_2 and -69 or 69):strokecolor(Color.Black) end,
+      InitCommand=function(self)
+        self:draworder(5):x(pn==pn_2 and -69 or 69):strokecolor(Color.Black)
+      end,
     },
-    ScoreAndGrade.GetGradeActor{
-      AlternativeFC = true,
-    }..{
+    ScoreAndGrade.CreateGradeActor{
       Name='GradeFrame',
-      InitCommand=function(s) s:x(pn==pn_2 and -148 or 140) end,
+      AlternativeFC=true,
+      InitCommand=function(self)
+        self:x(pn==pn_2 and -148 or 140)
+      end,
     }
     
   };

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/_Diff.lua
@@ -13,7 +13,10 @@ local function DrawDiffListItem(diff)
       
       local song = GAMESTATE:GetCurrentSong()
       local stepType = GAMESTATE:GetCurrentStyle():GetStepsType()
-      local steps = song:GetOneSteps(stepType, diff)
+      local steps
+      if song then
+        steps = song:GetOneSteps(stepType, diff)
+      end
       if not (song and steps) then
         s:diffusealpha(0.5)
         c.Score:visible(false)
@@ -27,7 +30,7 @@ local function DrawDiffListItem(diff)
         profile = PROFILEMAN:GetProfile(pn)
       else
         profile = PROFILEMAN:GetMachineProfile()
-      end;
+      end
       local scores = profile:GetHighScoreList(song, steps):GetHighScores()
       local score = scores[1]
       if not score then
@@ -35,6 +38,8 @@ local function DrawDiffListItem(diff)
         c.GradeFrame:visible(false)
         return
       end
+      c.Score:visible(true)
+      c.GradeFrame:visible(true)
       
       s:playcommand('SetScore', { Stats = score, Steps = steps })
     end;

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
@@ -1,5 +1,6 @@
 local Y_SPACING = 140
-local Radar = LoadModule "DDR Groove Radar.lua"
+local Radar = LoadModule('DDR Groove Radar.lua')
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 local numItems = 7
 
 local ver = ""
@@ -139,175 +140,78 @@ local function RivalsPanel(pn)
 			SetCommand=function(s)
 				local c = s:GetChildren()
 				local song = GAMESTATE:GetCurrentSong()
-				if song then
-					local steps = GAMESTATE:GetCurrentSteps(pn)
-					if steps then
-						c.Bar_underlay:visible(true)
-						if rival == 1 then
-							c.Bar_underlay:diffuse(Color.Red)
-							c.Text_place:settext(THEME:GetString("RecordList","MachineBest"))
-						elseif rival == 2 then
-							c.Bar_underlay:diffuse(color("#00a651"))
-							c.Text_place:settext(THEME:GetString("RecordList","BestScore"))
-						else
-							c.Bar_underlay:diffuse(color("#006cff"))
-							if rival == 3 then
-								c.Text_place:settext(THEME:GetString("RecordList","Rival1"))
-							elseif rival == 4 then
-								c.Text_place:settext(THEME:GetString("RecordList","Rival2"))
-							elseif rival == 5 then
-								c.Text_place:settext(THEME:GetString("RecordList","Rival3"))
-							end
-						end
-					end
-
-					local profile
-					local scorelist
-					local scores
-					local topgrade
-					local topscore = 0
-					c.GradeArea:visible(false)
-					c.Text_score:settext("")
-					c.Text_name:settext("")
-					c.GradeArea:GetChild("FCStar"):visible(false)
-
+				local steps = GAMESTATE:GetCurrentSteps(pn)
+				if song and steps then
+					c.Bar_underlay:visible(true)
 					if rival == 1 then
-						--Always show machine best.
-						profile = PROFILEMAN:GetMachineProfile()
-						scorelist = profile:GetHighScoreList(song,steps)
-						scores = scorelist:GetHighScores()
-						if scores[1] then
-							if ThemePrefs.Get("ConvertScoresAndGrades") then
-								topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-								topgrade = SN2Grading.ScoreToGrade(topscore,steps)
-							else
-								topscore = scores[1]:GetScore()
-								topgrade = scores[1]:GetGrade()
-							end
-						end
-						if topscore ~= 0 then
-							c.Text_score:settext(commify(topscore))
-							if scores[1]:GetName() ~= nil then
-								if scores[1]:GetName() == "" then
-									c.Text_name:settext("NO NAME")
-								else
-									c.Text_name:settext(scores[1]:GetName())
-								end
-							else
-								c.Text_name:settext("STEP")
-							end
-							local misses = scores[1]:GetTapNoteScore("TapNoteScore_Miss")+scores[1]:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                    		local boos = scores[1]:GetTapNoteScore("TapNoteScore_W5")
-                    		local goods = scores[1]:GetTapNoteScore("TapNoteScore_W4")
-                    		local greats = scores[1]:GetTapNoteScore("TapNoteScore_W3")
-                    		local perfects = scores[1]:GetTapNoteScore("TapNoteScore_W2")
-                    		local marvelous = scores[1]:GetTapNoteScore("TapNoteScore_W1")
-							c.GradeArea:visible(true)
-							c.GradeArea:GetChild("Grade"):Load(THEME:GetPathG("myMusicWheel/GradeDisplayEval",ToEnumShortString(topgrade)))
-							if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-								c.GradeArea:GetChild("FCStar"):visible(true)
-								if (greats+perfects) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W1"])
-								  :glowblink():effectperiod(0.20)
-								elseif greats == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W2"])
-								  :glowshift()
-								elseif (misses+boos+goods) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W3"])
-								  :stopeffect()
-								elseif (misses+boos) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W4"])
-									:stopeffect()
-								end;
-							end
-						end
+						c.Bar_underlay:diffuse(Color.Red)
+						c.Text_place:settext(THEME:GetString('RecordList','MachineBest'))
 					elseif rival == 2 then
-						--Always show player's High Score
-						profile = PROFILEMAN:GetProfile(pn)
-						scorelist = profile:GetHighScoreList(song,steps)
-						scores = scorelist:GetHighScores()
-						if scores[1] then
-							if ThemePrefs.Get("ConvertScoresAndGrades") then
-								topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-								topgrade = SN2Grading.ScoreToGrade(topscore,steps)
-							else
-								topscore = scores[1]:GetScore()
-								topgrade = scores[1]:GetGrade()
-							end
-						end
-						if topscore ~= 0 then
-							c.Text_score:settext(commify(topscore))
-							if scores[1]:GetName() ~= nil then
-								if scores[1]:GetName() == "" then
-									c.Text_name:settext("NO NAME")
-								else
-									c.Text_name:settext(scores[1]:GetName())
-								end
-							else
-								c.Text_name:settext("STEP")
-							end
-							local misses = scores[1]:GetTapNoteScore("TapNoteScore_Miss")+scores[1]:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                    		local boos = scores[1]:GetTapNoteScore("TapNoteScore_W5")
-                    		local goods = scores[1]:GetTapNoteScore("TapNoteScore_W4")
-                    		local greats = scores[1]:GetTapNoteScore("TapNoteScore_W3")
-                    		local perfects = scores[1]:GetTapNoteScore("TapNoteScore_W2")
-                    		local marvelous = scores[1]:GetTapNoteScore("TapNoteScore_W1")
-							c.GradeArea:visible(true)
-							c.GradeArea:GetChild("Grade"):Load(THEME:GetPathG("myMusicWheel/GradeDisplayEval",ToEnumShortString(topgrade)))
-							if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-								c.GradeArea:GetChild("FCStar"):visible(true)
-								if (greats+perfects) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W1"])
-								  :glowblink():effectperiod(0.20)
-								elseif greats == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W2"])
-								  :glowshift()
-								elseif (misses+boos+goods) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W3"])
-								  :stopeffect()
-								elseif (misses+boos) == 0 then
-									c.GradeArea:GetChild("FCStar"):diffuse(GameColor.Judgment["JudgmentLine_W4"])
-									:stopeffect()
-								end;
-							end
-						end
+						c.Bar_underlay:diffuse(color('#00a651'))
+						c.Text_place:settext(THEME:GetString('RecordList','BestScore'))
+					else
+						c.Bar_underlay:diffuse(color('#006cff'))
+						c.Text_place:settext(THEME:GetString('RecordList','Rival'..(rival-2)))
 					end
-							
 				end
+
+				local profile
+				if rival == 1 then
+					--Always show machine best.
+					profile = PROFILEMAN:GetMachineProfile()
+				elseif rival == 2 then
+					--Always show player's High Score
+					profile = PROFILEMAN:GetProfile(pn)
+				end
+				
+				local score
+				if profile then
+					local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+					score = scores[1]
+				end
+				
+				if not score then
+					c.Text_name:visible(false)
+					c.Text_name:settext('')
+					c.Text_score:visible(false)
+					c.GradeFrame:visible(false)
+					return
+				end
+				
+				c.Text_name:visible(true)
+				if score:GetName() == nil then
+					c.Text_name:settext('STEP')
+				elseif score:GetName() == '' then
+						c.Text_name:settext('NO NAME')
+				else
+					c.Text_name:settext(score:GetName())
+				end
+				
+				s:playcommand('SetGrade', { Highscore = score, Steps = steps })
 			end,
 			Def.Quad{
-				Name="Bar_underlay";
+				Name='Bar_underlay';
 				InitCommand=function(s) s:visible(false):setsize(410,28):faderight(0.75):diffusealpha(0.5) end,
 			};
 			Def.BitmapText{
-                Font="_avenirnext lt pro bold/25px",
-                Name="Text_place";
+                Font='_avenirnext lt pro bold/25px',
+                Name='Text_place';
                 Text=rival;
                 InitCommand=function(s) s:x(-200):strokecolor(Alpha(Color.Black,0.5)):zoom(0.7):halign(0):maxwidth(140) end,
             };
 			Def.BitmapText{
-                Name="Text_name",
-                Font="_avenirnext lt pro bold/20px",
+                Name='Text_name',
+                Font='_avenirnext lt pro bold/20px',
                 InitCommand=function(s) s:x(-60):halign(0):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
             };
-			Def.BitmapText{
-                Name="Text_score",
-                Font="_avenirnext lt pro bold/20px",
-                InitCommand=function(s) s:x(160):halign(1):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
-            };
-			Def.ActorFrame{
-				Name="GradeArea",
+			ScoreAndGrade.GetScoreActor{}..{
+				Name='Text_score',
+				InitCommand=function(s) s:x(160):halign(1):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
+			},
+			ScoreAndGrade.GetGradeActor{}..{
+				Name='GradeFrame',
 				InitCommand=function(s) s:x(190) end,
-				Def.Sprite{
-					Name="Grade",
-				},
-				Def.Sprite{
-					Name="FCStar",
-					Texture=THEME:GetPathG("","myMusicWheel/star.png"),
-					InitCommand=function(s) s:zoom(0.4):xy(14,5) end,
-				}
 			}
-			
 		}
 	end
 	return t
@@ -530,10 +434,10 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 				}
 			},
 			RivalsPanel(pn)..{
-		        InitCommand=function(s) s:y(260) end,
+				InitCommand=function(s) s:y(260) end,
 				StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
 				ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
-            };
+			},
 			RadarPanel(pn)..{
 				InitCommand=function(s) s:diffusealpha(0) end,
 				StartSelectingStepsMessageCommand=function(s) s:sleep(0.4):smooth(0.1):diffusealpha(0.5)

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
@@ -5,7 +5,7 @@ local numItems = 7
 
 local ver = ""
 if ThemePrefs.Get("SV") == "onepointzero" then
-  ver = "1_"
+	ver = "1_"
 end
 
 
@@ -15,7 +15,7 @@ local function DiffInputHandler(event)
 	local pn= event.PlayerNumber
 	local button = event.button
 	if event.type == "InputEventType_Release" then return end
-
+	
 	if (button == "Start") and GAMESTATE:IsPlayerEnabled(pn) and not keyset[pn] and getenv("OPList") == 0 then
 		keyset[pn] = true
 		MESSAGEMAN:Broadcast("OK"..pn)
@@ -76,59 +76,59 @@ local function SetActiveSelections()
 end
 
 local function RadarPanel(pn)
-    local GR = {
-        {-1,-122, "Stream"}, --STREAM
-        {-120,-43, "Voltage"}, --VOLTAGE
-        {-108,72, "Air"}, --AIR
-        {108,72, "Freeze"}, --FREEZE
-        {120,-43, "Chaos"}, --CHAOS
-    }
-    local t = Def.ActorFrame{
+	local GR = {
+		{-1,-122, "Stream"}, --STREAM
+		{-120,-43, "Voltage"}, --VOLTAGE
+		{-108,72, "Air"}, --AIR
+		{108,72, "Freeze"}, --FREEZE
+		{120,-43, "Chaos"}, --CHAOS
+	}
+	local t = Def.ActorFrame{
 		StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
 		ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
 	}
-
-    t[#t+1] = Def.ActorFrame{
-        Def.ActorFrame{
-            Name="Radar",
-            Def.Sprite{
-                Texture=THEME:GetPathG("","_shared/Radar/"..ver.."GrooveRadar base.png"),
-            },
-            Def.Sprite{
-                Texture=THEME:GetPathG("","_shared/Radar/sweep.png"),
-                InitCommand = function(s) s:zoom(1.35):spin():effectmagnitude(0,0,100) end,
+	
+	t[#t+1] = Def.ActorFrame{
+		Def.ActorFrame{
+			Name="Radar",
+			Def.Sprite{
+				Texture=THEME:GetPathG("","_shared/Radar/"..ver.."GrooveRadar base.png"),
+			},
+			Def.Sprite{
+				Texture=THEME:GetPathG("","_shared/Radar/sweep.png"),
+				InitCommand = function(s) s:zoom(1.35):spin():effectmagnitude(0,0,100) end,
 				OffCommand=function(s) s:stoptweening() end,
-            },
-            Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25))
-        }
-    }
-
-    for i,v in ipairs(GR) do
-        t[#t+1] = Def.ActorFrame{
-            InitCommand=function(s)
-                s:xy(v[1],v[2])
-            end,
-            Def.Sprite{
+			},
+			Radar.create_ddr_groove_radar("radar",0,0,pn,125,Alpha(PlayerColor(pn),0.25))
+		}
+	}
+	
+	for i,v in ipairs(GR) do
+		t[#t+1] = Def.ActorFrame{
+			InitCommand=function(s)
+				s:xy(v[1],v[2])
+			end,
+			Def.Sprite{
 				Texture=THEME:GetPathG("","_shared/Radar/"..ver.."RLabels"),
-                InitCommand=function(s) s:animate(0):setstate(i-1) end,
-            },
-            Def.BitmapText{
-                Font="_avenirnext lt pro bold/20px",
-                SetCommand=function(s)
-                    local song = GAMESTATE:GetCurrentSong()
-                    if song then
-                        local steps = GAMESTATE:GetCurrentSteps(pn)
-                        local value = lookup_ddr_radar_values(song, steps, pn)[i]
-                        s:settext(math.floor(value*100+0.5))
-                    else
-                        s:settext("")
-                    end
-                    s:strokecolor(color("#1f1f1f")):y(28)
-                end,
-            }
-        }
-    end
-    return t
+				InitCommand=function(s) s:animate(0):setstate(i-1) end,
+			},
+			Def.BitmapText{
+				Font="_avenirnext lt pro bold/20px",
+				SetCommand=function(s)
+					local song = GAMESTATE:GetCurrentSong()
+					if song then
+						local steps = GAMESTATE:GetCurrentSteps(pn)
+						local value = lookup_ddr_radar_values(song, steps, pn)[i]
+						s:settext(math.floor(value*100+0.5))
+					else
+						s:settext("")
+					end
+					s:strokecolor(color("#1f1f1f")):y(28)
+				end,
+			}
+		}
+	end
+	return t
 end
 
 local function RivalsPanel(pn)
@@ -154,7 +154,7 @@ local function RivalsPanel(pn)
 						c.Text_place:settext(THEME:GetString('RecordList','Rival'..(rival-2)))
 					end
 				end
-
+				
 				local profile
 				if rival == 1 then
 					--Always show machine best.
@@ -199,16 +199,16 @@ local function RivalsPanel(pn)
 				InitCommand=function(s) s:visible(false):setsize(410,28):faderight(0.75):diffusealpha(0.5) end,
 			};
 			Def.BitmapText{
-                Font='_avenirnext lt pro bold/25px',
-                Name='Text_place';
-                Text=rival;
-                InitCommand=function(s) s:x(-200):strokecolor(Alpha(Color.Black,0.5)):zoom(0.7):halign(0):maxwidth(140) end,
-            };
+				Font='_avenirnext lt pro bold/25px',
+				Name='Text_place';
+				Text=rival;
+				InitCommand=function(s) s:x(-200):strokecolor(Alpha(Color.Black,0.5)):zoom(0.7):halign(0):maxwidth(140) end,
+			};
 			Def.BitmapText{
-                Name='Text_name',
-                Font='_avenirnext lt pro bold/20px',
-                InitCommand=function(s) s:x(-60):halign(0):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
-            };
+				Name='Text_name',
+				Font='_avenirnext lt pro bold/20px',
+				InitCommand=function(s) s:x(-60):halign(0):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
+			};
 			ScoreAndGrade.CreateScoreActor{
 				Name='Text_score',
 				InitCommand=function(self)
@@ -228,7 +228,7 @@ end
 
 local function genScrollerFrame(pn)
 	local t = Def.ActorFrame{}
-
+	
 	t[#t+1] = Def.DynamicActorScroller{
 		NumItemsToDraw = numItems,
 		SecondsPerItem = 0.1,
@@ -236,7 +236,7 @@ local function genScrollerFrame(pn)
 		OnCommand=function(self)
 			-- For more information about this Input Controller, check "Custom Input".
 			-- https://outfox.wiki/dev/theming/Theming-Custom-Input/
-	
+			
 			-- TRICK: Make the scroller be outside of range, so by the time it comes back,
 			-- it has been loaded with the present steps data.
 			self:SetCurrentAndDestinationItem( numItems+2 )
@@ -247,9 +247,9 @@ local function genScrollerFrame(pn)
 		StartSelectingStepsMessageCommand=function (self)
 			local song = GAMESTATE:GetCurrentSong()
 			stepsData = SongUtil.GetPlayableSteps(song)
-	
+			
 			SetActiveSelections()
-	
+			
 			-- Force the scroller to update its items.
 			self:SetCurrentAndDestinationItem( selection[pn]-1 )
 			self:sleep(0.1)
@@ -258,7 +258,7 @@ local function genScrollerFrame(pn)
 		LoadFunction = function(self, itemIndex)
 			-- This will tell the scroller how many items will be generated for the scroller. It just needs a number.
 			-- "Call the expression with line = nil to find out the number of lines."
-	
+			
 			-- Self is the actor represented for the actor set.
 			-- itemIndex is the item relative to the current selection from the user.
 			if self then
@@ -272,33 +272,33 @@ local function genScrollerFrame(pn)
 					self:GetChild("CFBPMDisplay"):settext( steps:GetAuthorCredit() ):diffuse(CustomDifficultyTwoPartToColor(diff))
 					self:GetChild("ShockArrow"):visible( steps:GetRadarValues(pn):GetValue('RadarCategory_Mines') >= 1 )
 					self:GetChild("Highlight").indexValue = itemIndex
-
+					
 					-- Handle highscore lamp.
 					local profile
 					local song = GAMESTATE:GetCurrentSong()
-
+					
 					if not song then return numItems end
-
+					
 					if PROFILEMAN:IsPersistentProfile(pn) then
 						profile = PROFILEMAN:GetProfile(pn)
 					else
 						profile = PROFILEMAN:GetMachineProfile()
 					end
-
+					
 					local scorelist = profile:GetHighScoreList(song,steps)
 					local scores = scorelist:GetHighScores()
 					local topscore
-
+					
 					local lampActor = self:GetChild("Lamp")
 					if scores[1] then
 						topscore = scores[1]
 						assert(topscore)
-                		local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-                		local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-                		local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-                		local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-                		local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-                		local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
+						local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
+						local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
+						local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
+						local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
+						local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
+						local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
 						if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
 							if (greats+perfects) == 0 then
 								lampActor:diffuse(FullComboEffectColor["JudgmentLine_W1"]):glowblink():effectperiod(0.20)
@@ -326,7 +326,7 @@ local function genScrollerFrame(pn)
 		end,
 		TransformFunction=function(self, offset, itemIndex, numItems)
 			self:y( offset * Y_SPACING )
-
+			
 			self:diffusealpha( (offset < -3 or offset > 3) and 0 or 1 )
 		end,
 		-- By the rules, this is only adding a single item, which is an ActorFrame holding a BitmapText.
@@ -389,7 +389,7 @@ local function genScrollerFrame(pn)
 			end
 		end,
 	}
-
+	
 	return t
 end
 
@@ -426,57 +426,57 @@ for _,pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 					s:zoomx(pn==PLAYER_2 and -1 or 1)
 				end,
 				Def.Sprite{ Texture="WINDOW INNER",
-					InitCommand=function(s) s:diffuse(color("#333333")):y(14) end,
-				},
-				Def.Sprite{ Texture="WINDOW FRAME"}
+				InitCommand=function(s) s:diffuse(color("#333333")):y(14) end,
 			},
-			Def.ActorFrame{
-				Name="DIFF HEADER",
-				--Blaze it
-				InitCommand=function(s) s:y(-420) end,
-				Def.Sprite{
-					Texture="Header Box",
-					InitCommand=function(s) s:zoomx(pn==PLAYER_2 and -1 or 1) end,
-				},
-				Def.Sprite{
-					Texture="Diff Text",
-				}
+			Def.Sprite{ Texture="WINDOW FRAME"}
+		},
+		Def.ActorFrame{
+			Name="DIFF HEADER",
+			--Blaze it
+			InitCommand=function(s) s:y(-420) end,
+			Def.Sprite{
+				Texture="Header Box",
+				InitCommand=function(s) s:zoomx(pn==PLAYER_2 and -1 or 1) end,
 			},
-			RivalsPanel(pn)..{
-				InitCommand=function(s) s:y(260) end,
-				StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
-				ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
-			},
-			RadarPanel(pn)..{
-				InitCommand=function(s) s:diffusealpha(0) end,
-				StartSelectingStepsMessageCommand=function(s) s:sleep(0.4):smooth(0.1):diffusealpha(0.5)
-					:smooth(0.1):diffusealpha(0.3):decelerate(0.3):diffusealpha(1)
-				end,
-			},
-			loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/TwoPartDiff/_Diff.lua"))(pn)..{
-				InitCommand=function(s) s:y(-360) end,
-				StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
-				ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
+			Def.Sprite{
+				Texture="Diff Text",
 			}
 		},
-		--Yes I'm loading a version of the diff list that literally only has the frame removed. Fight me.
-		Def.BitmapText{
-			Font="_avenirnext lt pro bold/25px",
-			Text="Please wait...",
-			InitCommand=function(s) s:diffusealpha(0):y(60):strokecolor(Color.Black):sleep(0.4) end,
-			AnimCommand=function(s) s:finishtweening():cropright(0.2):linear(0.5):cropright(0):queuecommand("Anim") end,
-			["OK"..pn.."MessageCommand"]=function(s)
-				s:x(-100):decelerate(0.4):x(0):diffusealpha(1):queuecommand("Anim")
+		RivalsPanel(pn)..{
+			InitCommand=function(s) s:y(260) end,
+			StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
+			ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
+		},
+		RadarPanel(pn)..{
+			InitCommand=function(s) s:diffusealpha(0) end,
+			StartSelectingStepsMessageCommand=function(s) s:sleep(0.4):smooth(0.1):diffusealpha(0.5)
+				:smooth(0.1):diffusealpha(0.3):decelerate(0.3):diffusealpha(1)
 			end,
-			RemoveCommand=function (self)
-				self:stoptweening():decelerate(0.4):x(0):diffusealpha(0)
-			end,
-			OffCommand=function(s) 
-				s:settext("O.K.!")
-				:finishtweening():diffusealpha(1):sleep(1):decelerate(0.3):diffusealpha(0)
-			end,
+		},
+		loadfile(THEME:GetPathB("ScreenSelectMusic","decorations/_shared/TwoPartDiff/_Diff.lua"))(pn)..{
+			InitCommand=function(s) s:y(-360) end,
+			StartSelectingStepsMessageCommand=function(s) s:queuecommand("Set") end,
+			ChangeStepsMessageCommand=function(s) s:queuecommand("Set") end,
 		}
+	},
+	--Yes I'm loading a version of the diff list that literally only has the frame removed. Fight me.
+	Def.BitmapText{
+		Font="_avenirnext lt pro bold/25px",
+		Text="Please wait...",
+		InitCommand=function(s) s:diffusealpha(0):y(60):strokecolor(Color.Black):sleep(0.4) end,
+		AnimCommand=function(s) s:finishtweening():cropright(0.2):linear(0.5):cropright(0):queuecommand("Anim") end,
+		["OK"..pn.."MessageCommand"]=function(s)
+			s:x(-100):decelerate(0.4):x(0):diffusealpha(1):queuecommand("Anim")
+		end,
+		RemoveCommand=function (self)
+			self:stoptweening():decelerate(0.4):x(0):diffusealpha(0)
+		end,
+		OffCommand=function(s) 
+			s:settext("O.K.!")
+			:finishtweening():diffusealpha(1):sleep(1):decelerate(0.3):diffusealpha(0)
+		end,
 	}
+}
 end
 
 return af

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
@@ -161,7 +161,11 @@ local function RivalsPanel(pn)
 					profile = PROFILEMAN:GetMachineProfile()
 				elseif rival == 2 then
 					--Always show player's High Score
-					profile = PROFILEMAN:GetProfile(pn)
+					if PROFILEMAN:IsPersistentProfile(pn) then
+						profile = PROFILEMAN:GetProfile(pn)
+					else
+						profile = PROFILEMAN:GetMachineProfile()
+					end
 				end
 				
 				local score
@@ -171,20 +175,21 @@ local function RivalsPanel(pn)
 				end
 				
 				if not score then
-					c.Text_name:visible(false)
 					c.Text_name:settext('')
+					c.Text_name:visible(false)
 					c.Text_score:visible(false)
 					c.GradeFrame:visible(false)
 					return
 				end
-				
 				c.Text_name:visible(true)
-				if score:GetName() == nil then
-					c.Text_name:settext('STEP')
-				elseif score:GetName() == '' then
-						c.Text_name:settext('NO NAME')
+				c.Text_score:visible(true)
+				c.GradeFrame:visible(true)
+				
+				local name = score:GetName()
+				if not name or name == ''  then
+					c.Text_name:settext('(NO NAME)')
 				else
-					c.Text_name:settext(score:GetName())
+					c.Text_name:settext(name)
 				end
 				
 				s:playcommand('SetScore', { Stats = score, Steps = steps })

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/TwoPartDiff/default.lua
@@ -187,7 +187,7 @@ local function RivalsPanel(pn)
 					c.Text_name:settext(score:GetName())
 				end
 				
-				s:playcommand('SetGrade', { Highscore = score, Steps = steps })
+				s:playcommand('SetScore', { Stats = score, Steps = steps })
 			end,
 			Def.Quad{
 				Name='Bar_underlay';
@@ -204,13 +204,17 @@ local function RivalsPanel(pn)
                 Font='_avenirnext lt pro bold/20px',
                 InitCommand=function(s) s:x(-60):halign(0):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
             };
-			ScoreAndGrade.GetScoreActor{}..{
+			ScoreAndGrade.CreateScoreActor{
 				Name='Text_score',
-				InitCommand=function(s) s:x(160):halign(1):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8) end,
+				InitCommand=function(self)
+					self:x(160):halign(1):diffuse(Color.White):strokecolor(Color.Black):zoom(0.8)
+				end,
 			},
-			ScoreAndGrade.GetGradeActor{}..{
+			ScoreAndGrade.CreateGradeActor{
 				Name='GradeFrame',
-				InitCommand=function(s) s:x(190) end,
+				InitCommand=function(self)
+					self:x(190)
+				end,
 			}
 		}
 	end

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/_Difficulty/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/_Difficulty/default.lua
@@ -45,7 +45,7 @@ local function DrawDiffListItem(diff)
       c.Score:visible(true)
       c.GradeFrame:visible(true)
       
-      self:playcommand('SetGrade', { Highscore = score, Steps = steps })
+      self:playcommand('SetScore', { Stats = score, Steps = steps })
     end;
     Def.Quad{
       Name="Background";
@@ -78,15 +78,18 @@ local function DrawDiffListItem(diff)
       end;
     };
 
-    ScoreAndGrade.GetScoreActor{}..{
+    ScoreAndGrade.CreateScoreActor{
       Name='Score',
-      InitCommand=function(s) s:draworder(5):x(pn==pn_2 and -69 or 69):strokecolor(Color.Black) end,
+      InitCommand=function(self)
+        self:draworder(5):x(pn==pn_2 and -69 or 69):strokecolor(Color.Black)
+      end,
     },
-    ScoreAndGrade.GetGradeActor{
-      AlternativeFC = true,
-    }..{
+    ScoreAndGrade.CreateGradeActor{
       Name='GradeFrame',
-      InitCommand=function(s) s:x(pn==pn_2 and -148 or 140) end,
+      AlternativeFC=true,
+      InitCommand=function(self)
+        self:x(pn==pn_2 and -148 or 140)
+      end,
     }
     
   };

--- a/BGAnimations/ScreenSelectMusic decorations/_shared/_Difficulty/default.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/_shared/_Difficulty/default.lua
@@ -25,18 +25,17 @@ local function DrawDiffListItem(diff)
         return
       end
       self:diffusealpha(1)
-      
-      local meter = steps:GetMeter()
-      c.Meter:settext(IsMeterDec(meter)):visible(true)
+      c.Meter:visible(true):settext(IsMeterDec(steps:GetMeter()))
       
       local profile
       if PROFILEMAN:IsPersistentProfile(pn) then
         profile = PROFILEMAN:GetProfile(pn)
       else
         profile = PROFILEMAN:GetMachineProfile()
-      end;
+      end
       local scores = profile:GetHighScoreList(song, steps):GetHighScores()
       local score = scores[1]
+      
       if not score then
         c.Score:visible(false)
         c.GradeFrame:visible(false)
@@ -46,7 +45,7 @@ local function DrawDiffListItem(diff)
       c.GradeFrame:visible(true)
       
       self:playcommand('SetScore', { Stats = score, Steps = steps })
-    end;
+    end,
     Def.Quad{
       Name="Background";
       InitCommand=function(s) s:setsize(336,28):diffusealpha(0.8):draworder(0) end,

--- a/BGAnimations/ScreenStageInformation decorations/record.lua
+++ b/BGAnimations/ScreenStageInformation decorations/record.lua
@@ -1,4 +1,5 @@
 local t = Def.ActorFrame{};
+local ScoreAndGrade = LoadModule('ScoreAndGrade.lua')
 
 local xPosPlayer = {
     P1 = SCREEN_LEFT+280,
@@ -8,9 +9,27 @@ local xPosPlayer = {
 for _, pn in pairs(GAMESTATE:GetEnabledPlayers()) do
 
 t[#t+1] = Def.ActorFrame{
-  InitCommand=function(self)
+  InitCommand=function(s)
     local short = ToEnumShortString(pn)
-    self:x(xPosPlayer[short]):y(_screen.cy+180)
+    s:x(xPosPlayer[short]):y(_screen.cy+180)
+    local c = s:GetChildren()
+    
+    local song = GAMESTATE:GetCurrentSong()
+    local steps = GAMESTATE:GetCurrentSteps(pn)
+    local score
+    if song and steps then
+      local profile
+      if PROFILEMAN:IsPersistentProfile(pn) then
+        profile = PROFILEMAN:GetProfile(pn)
+      else
+        profile = PROFILEMAN:GetMachineProfile()
+      end
+
+      local scores = profile:GetHighScoreList(song, steps):GetHighScores()
+      score = scores[1]
+    end
+    
+    s:playcommand('SetGrade', { Highscore = score, Steps = steps })
   end;
   OnCommand=function(self)
     if pn == PLAYER_1 then
@@ -36,46 +55,14 @@ t[#t+1] = Def.ActorFrame{
       s:xy(pn==PLAYER_1 and -200 or 200,-60)
     end
   };
-  Def.BitmapText{
-    Name="ScoreNumber";
-    Font="ScoreDisplayNormal Text";
+  ScoreAndGrade.GetScoreActorRolling{
+    Font='ScoreDisplayNormal Text',
+  }..{
+    Name='Score',
     InitCommand=function(self)
-      self:xy(pn=='PlayerNumber_P2' and 46 or -46,-32)
+      self:xy(pn=='PlayerNumber_P2' and 46 or -46,-32):strokecolor(Color.Black)
     end;
-    BeginCommand=function(s) s:playcommand("Set") end,
-    SetCommand=function(self)
-      self:settext("")
-
-      local song=GAMESTATE:GetCurrentSong()
-      if song then
-        local steps = GAMESTATE:GetCurrentSteps(pn);
-        local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-
-        if PROFILEMAN:IsPersistentProfile(pn) then
-          profile = PROFILEMAN:GetProfile(pn)
-        else
-          profile = PROFILEMAN:GetMachineProfile()
-        end;
-
-        scorelist = profile:GetHighScoreList(song,steps)
-        local scores = scorelist:GetHighScores()
-        local topscore = 0
-
-        if scores[1] then
-          topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-        end;
-
-        self:strokecolor(Color.Black)
-        self:diffusealpha(1)
-
-        if topscore ~= 0 then
-          self:settext(commify(topscore))
-        else
-          self:settext("0,000,000")
-        end
-      end
-    end;
-  };
+  },
   Def.BitmapText{
     Font="_avenirnext lt pro bold/42px";
     InitCommand=function(self)
@@ -127,130 +114,10 @@ t[#t+1] = Def.ActorFrame{
       s:settext(THEME:GetString("CustomDifficulty",ToEnumShortString(diff))):uppercase(true):diffuse(CustomDifficultyToColor(diff))
     end;
   };
-  Def.ActorFrame{
-    InitCommand=function(s) s:xy(pn=='PlayerNumber_P2' and -200 or 220,-32) end,
-    Def.Sprite{
-      Texture=THEME:GetPathG("Player","Badge FullCombo"),
-      InitCommand=function(s) s:xy(6,6):zoom(0.75) end,
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        local st=GAMESTATE:GetCurrentStyle():GetStepsType();
-        local song=GAMESTATE:GetCurrentSong();
-        if song then
-          local steps = GAMESTATE:GetCurrentSteps(pn);
-  
-          if PROFILEMAN:IsPersistentProfile(pn) then
-            profile = PROFILEMAN:GetProfile(pn);
-          else
-            profile = PROFILEMAN:GetMachineProfile();
-          end;
-          local scorelist = profile:GetHighScoreList(song,steps);
-          assert(scorelist);
-          local scores = scorelist:GetHighScores();
-          assert(scores);
-          local topscore;
-          if scores[1] then
-            topscore = scores[1];
-            assert(topscore);
-            local misses = topscore:GetTapNoteScore("TapNoteScore_Miss")+topscore:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-            local boos = topscore:GetTapNoteScore("TapNoteScore_W5")
-            local goods = topscore:GetTapNoteScore("TapNoteScore_W4")
-            local greats = topscore:GetTapNoteScore("TapNoteScore_W3")
-            local perfects = topscore:GetTapNoteScore("TapNoteScore_W2")
-            local marvelous = topscore:GetTapNoteScore("TapNoteScore_W1")
-            if (misses+boos) == 0 and scores[1]:GetScore() > 0 and (marvelous+perfects)>0 then
-              if (greats+perfects) == 0 then
-                self:diffuse(GameColor.Judgment["JudgmentLine_W1"]);
-                self:glowblink();
-                self:effectperiod(0.20);
-              elseif greats == 0 then
-                self:diffuse(GameColor.Judgment["JudgmentLine_W2"]);
-                self:glowshift();
-              elseif (misses+boos+goods) == 0 then
-                self:diffuse(GameColor.Judgment["JudgmentLine_W3"]);
-                self:stopeffect();
-              elseif (misses+boos) == 0 then
-                self:diffuse(GameColor.Judgment["JudgmentLine_W4"]);
-                self:stopeffect();
-              end;
-              self:diffusealpha(1);
-            else
-              self:diffusealpha(0);
-            end;
-          else
-            self:diffusealpha(0);
-          end;
-        else
-          self:diffusealpha(0);
-        end;
-      end;
-    };
-    Def.Quad{
-      InitCommand=function(self)
-        self:zoom(0.1)
-      end;
-      BeginCommand=function(s) s:playcommand("Set") end,
-      SetCommand=function(self)
-        local song = GAMESTATE:GetCurrentSong();
-        local steps = GAMESTATE:GetCurrentSteps(pn);
-        if song then
-          local st = GAMESTATE:GetCurrentStyle():GetStepsType()
-          local diff = steps:GetDifficulty();
-  
-          if PROFILEMAN:IsPersistentProfile(pn) then
-            -- player profile
-            profile = PROFILEMAN:GetProfile(pn);
-          else
-            -- machine profile
-            profile = PROFILEMAN:GetMachineProfile();
-          end;
-  
-          scorelist = profile:GetHighScoreList(song,steps);
-          assert(scorelist);
-  
-          local scores = scorelist:GetHighScores();
-          assert(scores);
-  
-          local topscore=0;
-          if scores[1] then
-            topscore = SN2Scoring.GetSN2ScoreFromHighScore(steps, scores[1])
-            topscore2 = scores[1];
-          end;
-          assert(topscore);
-          if scores[1] then
-            local misses = topscore2:GetTapNoteScore("TapNoteScore_Miss")+topscore2:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-            local boos = topscore2:GetTapNoteScore("TapNoteScore_W5")
-            local goods = topscore2:GetTapNoteScore("TapNoteScore_W4")
-            local greats = topscore2:GetTapNoteScore("TapNoteScore_W3")
-            local perfects = topscore2:GetTapNoteScore("TapNoteScore_W2")
-            local marvelous = topscore2:GetTapNoteScore("TapNoteScore_W1")
-            if (misses+boos) == 0 and topscore > 0 and (marvelous+perfects)>0 then
-              self:addx(-14)
-            end;
-          end;
-          if scores[1] then
-            local topgrade = scores[1]:GetGrade();
-            local tier = SN2Grading.ScoreToGrade(topscore, diff)
-            assert(topgrade);
-            if scores[1]:GetScore()>1  then
-              if topgrade == 'Grade_Failed' then
-                self:Load(THEME:GetPathB("","ScreenEvaluationNormal decorations/grade/GradeDisplayEval Failed"));
-              else
-                self:Load(THEME:GetPathB("ScreenEvaluationNormal decorations/grade/GradeDisplayEval",ToEnumShortString(tier)));
-              end;
-              self:diffusealpha(1);
-            else
-              self:diffusealpha(0);
-            end;
-          else
-            self:diffusealpha(0);
-          end;
-        else
-          self:diffusealpha(0);
-        end;
-      end;
-    };
-  }
+  ScoreAndGrade.GetGradeActor{}..{
+    Name='Grade',
+    InitCommand=function(s) s:xy(pn=='PlayerNumber_P2' and -200 or 200,-32):zoom(1.4) end
+  },
 }
 end;
 

--- a/BGAnimations/ScreenStageInformation decorations/record.lua
+++ b/BGAnimations/ScreenStageInformation decorations/record.lua
@@ -29,7 +29,7 @@ t[#t+1] = Def.ActorFrame{
       score = scores[1]
     end
     
-    s:playcommand('SetGrade', { Highscore = score, Steps = steps })
+    s:playcommand('SetScore', { Stats = score, Steps = steps })
   end;
   OnCommand=function(self)
     if pn == PLAYER_1 then
@@ -55,13 +55,12 @@ t[#t+1] = Def.ActorFrame{
       s:xy(pn==PLAYER_1 and -200 or 200,-60)
     end
   };
-  ScoreAndGrade.GetScoreActorRolling{
-    Font='ScoreDisplayNormal Text',
-  }..{
+  ScoreAndGrade.CreateScoreRollingActor{
     Name='Score',
+    Font='ScoreDisplayNormal Text',
     InitCommand=function(self)
       self:xy(pn=='PlayerNumber_P2' and 46 or -46,-32):strokecolor(Color.Black)
-    end;
+    end,
   },
   Def.BitmapText{
     Font="_avenirnext lt pro bold/42px";
@@ -114,9 +113,11 @@ t[#t+1] = Def.ActorFrame{
       s:settext(THEME:GetString("CustomDifficulty",ToEnumShortString(diff))):uppercase(true):diffuse(CustomDifficultyToColor(diff))
     end;
   };
-  ScoreAndGrade.GetGradeActor{}..{
+  ScoreAndGrade.CreateGradeActor{
     Name='Grade',
-    InitCommand=function(s) s:xy(pn=='PlayerNumber_P2' and -200 or 200,-32):zoom(1.4) end
+    InitCommand=function(self)
+      self:xy(pn=='PlayerNumber_P2' and -200 or 200,-32):zoom(1.4)
+    end,
   },
 }
 end;

--- a/BGAnimations/ScreenStageInformation decorations/record.lua
+++ b/BGAnimations/ScreenStageInformation decorations/record.lua
@@ -30,7 +30,13 @@ t[#t+1] = Def.ActorFrame{
     end
     
     s:playcommand('SetScore', { Stats = score, Steps = steps })
-  end;
+    
+    if score then
+      c.Score_Name:settext(score:GetName())
+    else
+      c.Score_Name:settext('')
+    end
+  end,
   OnCommand=function(self)
     if pn == PLAYER_1 then
       self:addx(-800):sleep(1.2):decelerate(0.2):addx(800)
@@ -63,6 +69,7 @@ t[#t+1] = Def.ActorFrame{
     end,
   },
   Def.BitmapText{
+    Name='Score_Name',
     Font="_avenirnext lt pro bold/42px";
     InitCommand=function(self)
       self:y(14)
@@ -71,7 +78,6 @@ t[#t+1] = Def.ActorFrame{
     end;
     SetCommand=function(s)
       s:maxwidth(434);
-      s:settext(PROFILEMAN:GetProfile(pn):GetDisplayName())
     end;
   };
   Def.BitmapText{

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -1,0 +1,258 @@
+
+local ScoreAndGrade = {}
+
+local DEBUG = false
+
+-- Should we maybe have this in SN2Scoring instead?
+local defaultTierToSN2TierTable = {
+  Grade_Tier01 = 'Grade_Tier02', -- AAA
+  Grade_Tier02 = 'Grade_Tier04', -- AA
+  Grade_Tier03 = 'Grade_Tier07', -- A
+  Grade_Tier04 = 'Grade_Tier10', -- B 
+  Grade_Tier05 = 'Grade_Tier13', -- C
+  Grade_Tier06 = 'Grade_Tier16', -- D
+  Grade_Tier07 = 'Grade_Tier17', -- D
+}
+function ScoreAndGrade.DefaultTierToSN2Tier(tier)
+  local output = defaultTierToSN2TierTable[tier]
+  assert(output, 'Unknown tier:' .. tier)
+  return output
+end
+
+function ScoreAndGrade.GetFCType(obj)
+  if DEBUG then return 'TapNoteScore_W1' end -- For testing
+  
+  local tnsFunc, hnsFunc
+  if lua.CheckType('PlayerStageStats', obj) then
+    tnsFunc, hnsFunc = obj['GetTapNoteScores'], obj['GetHoldNoteScores']
+  elseif lua.CheckType('HighScore', obj) then
+    tnsFunc, hnsFunc = obj['GetTapNoteScore'], obj['GetHoldNoteScore']
+  else
+    error('First argument is not HighScore or PlayerStageStats')
+  end
+  assert(tnsFunc)
+  assert(hnsFunc)
+  
+  if obj:GetScore() == 0                             -- If nothing was scored
+  or hnsFunc(obj, 'HoldNoteScore_LetGo') > 0         -- or any hold note was let go too early 
+  or tnsFunc(obj, 'TapNoteScore_CheckpointMiss') > 0 -- or any hold note checkpoint was missed
+  or tnsFunc(obj, 'TapNoteScore_Miss') > 0           -- or any tap note was missed
+  or tnsFunc(obj, 'TapNoteScore_W5') > 0 then        -- or any tap note was boos
+    return nil
+  end
+  
+  for _, tns in ipairs({
+    'TapNoteScore_W4',
+    'TapNoteScore_W3',
+    'TapNoteScore_W2',
+    'TapNoteScore_W1'
+  }) do
+    if tnsFunc(obj, tns) > 0 then
+      return tns
+    end
+  end
+  
+  return nil
+end
+
+function ScoreAndGrade.GetScore(hs, steps, showEX)
+  if DEBUG then return showEX and 300 or 1000000 end -- for testing
+  if showEX then
+    return SN2Scoring.ComputeEXScoreFromData(SN2Scoring.GetCurrentScoreData(hs))
+  end
+  
+  if ThemePrefs.Get('ConvertScoresAndGrades') then
+    return SN2Scoring.GetSN2ScoreFromHighScore(steps, hs)
+  end
+  
+  return hs:GetScore()
+end
+
+function ScoreAndGrade.GetGrade(hs, steps)
+  if DEBUG then return 'Grade_Tier01' end -- for testing  
+  if ThemePrefs.Get('ConvertScoresAndGrades') then
+    local score = SN2Scoring.GetSN2ScoreFromHighScore(steps, hs)
+    return SN2Grading.ScoreToGrade(score)
+  end
+  
+  return ScoreAndGrade.DefaultTierToSN2Tier(hs:GetGrade())
+end
+
+function ScoreAndGrade.GetScoreActor(opt_in)
+  local opts = {
+    Font = '_avenirnext lt pro bold/20px',
+    ShowEXScore = false,
+  }
+  if opts_in then
+    for k, v in pairs(opts_in) do opts[k] = v end
+  end
+  
+  local t = Def.BitmapText{
+    Font=opts.Font,
+    SetGradeCommand = function(s, params)
+      local hs = params.Highscore
+      local steps = params.Steps
+    
+      local score
+      if hs then
+        assert(steps)
+        score = ScoreAndGrade.GetScore(hs, steps, opts.ShowEXScore)
+      end
+      
+      s:settext(score and commify(score) or '0')
+    end
+  }
+  
+  return t
+end
+
+function ScoreAndGrade.GetScoreActorRolling(opts_in)
+  local opts = {
+    Font = '_avenirnext lt pro bold/46px',
+    ShowEXScore = false,
+    Load = 'RollingNumbers',
+  }
+  if opts_in then
+    for k, v in pairs(opts_in) do opts[k] = v end
+  end
+  
+  local t = Def.RollingNumbers{
+    Font = opts.Font,
+    SetGradeCommand = function(s, params)
+      local hs = params.Highscore
+      local steps = params.Steps
+      
+      local score
+      if hs then
+        assert(steps)
+        score = ScoreAndGrade.GetScore(hs, steps, opts.ShowEXScore)
+      end
+      s:Load(opts.Load):targetnumber(score and score or 0)
+    end
+  }
+  
+  return t
+end
+
+function ScoreAndGrade.GetGradeActor(opts_in)
+  local opts = {
+    Big = false,
+    AlternativeFC = false,  -- Only effective if Big = false
+    ActorConcat = nil,      -- Used to apply special OnCommand/OffCommand
+  }
+  if opts_in then
+    for k, v in pairs(opts_in) do opts[k] = v end
+  end
+  local ActorConcat = opts.ActorConcat or {}
+  
+  local FullCombo
+  if opts.Big then 
+    FullCombo = Def.ActorFrame{
+      InitCommand=function(s) s:xy(170, 50):visible(false) end,
+      Def.ActorFrame{
+        Name='StarFrame',
+        FOV=120,
+        InitCommand=function(s) s:zoom(0):bob():effectmagnitude(0,0,20) end,
+        OnCommand=function(s) s:sleep(0.5):linear(0.2):zoom(0.8) end,
+        OffCommand=function(s) s:linear(0.2):zoom(0) end,
+        Def.ActorFrame{
+          Name='Star1',
+          InitCommand=function(s) s:spin():effectmagnitude(0,0,-170) end,
+          Def.Sprite{
+            Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/star.png"),
+          },
+          Def.Sprite{
+            Name='ColorStar',
+            Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/colorstar.png"),
+          }
+        };
+        Def.ActorFrame{
+          Name='Star2',
+          InitCommand=function(s) s:spin():effectmagnitude(0,0,80):diffusealpha(0.5) end,
+          Def.Sprite{
+            Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/star.png"),
+          },
+          Def.Sprite{
+            Name='ColorStar',
+            Texture=THEME:GetPathB("ScreenEvaluationNormal","decorations/grade/colorstar.png"),
+          }
+        }
+      }
+		}
+  else
+    FullCombo = Def.Sprite{
+      InitCommand=function(s)
+        s:visible(false)
+        if opts.AlternativeFC then 
+          s:xy(18,4):Load(THEME:GetPathG("Player","Badge FullCombo")):zoom(0.5):shadowlength(1)
+        else
+          s:xy(14,5):Load(THEME:GetPathG('','myMusicWheel/star.png')):zoom(0.4)
+        end
+      end,
+    }
+  end
+    
+  local t = Def.ActorFrame{
+    SetGradeCommand = function(s, params)
+      local hs = params.Highscore
+      local steps = params.Steps
+      
+      local grade
+      if hs then
+        assert(steps)
+        grade = ScoreAndGrade.GetGrade(hs, steps)
+      end
+      
+      if not grade then
+        s:visible(false)
+        return
+      end
+      s:visible(true)
+      local Grade = s:GetChild('Grade')
+      local FullCombo = s:GetChild('FullCombo')
+      
+      if opts.Big then
+        Grade:Load(THEME:GetPathB('ScreenEvaluationNormal decorations/grade/GradeDisplayEval', ToEnumShortString(grade)))
+      else
+        Grade:Load(THEME:GetPathG('myMusicWheel/GradeDisplayEval', ToEnumShortString(grade)))
+      end
+      
+      local fullComboType = ScoreAndGrade.GetFCType(hs)
+      if not fullComboType then
+        FullCombo:visible(false)
+        return
+      end
+      FullCombo:visible(true)
+      
+      if opts.Big then
+        local ringColor = FullComboEffectColor[fullComboType]
+        if not ringColor then
+          assert(false, 'Unknown Full Combo type: ' .. fullComboType)
+          return
+        end
+        
+        local StarFrame = FullCombo:GetChild('StarFrame')
+        StarFrame:GetChild('Star1'):GetChild('ColorStar'):diffuse(ringColor)
+        StarFrame:GetChild('Star2'):GetChild('ColorStar'):diffuse(ringColor)
+      else
+        if     fullComboType == 'TapNoteScore_W1' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.20)
+        elseif fullComboType == 'TapNoteScore_W2' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
+        elseif fullComboType == 'TapNoteScore_W3' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
+        elseif fullComboType == 'TapNoteScore_W4' then FullCombo:diffuse(GameColor.Judgment['TapNoteScore_W4']):stopeffect()
+        else
+          assert(false, 'Unknown Full Combo type: ' .. fullComboType)
+        end
+      end
+    end,
+    (Def.Sprite{
+      Name='Grade',
+    })..(ActorConcat['Grade'] or {}),
+    (FullCombo..{
+      Name='FullCombo',
+    })..(ActorConcat['FullCombo'] or {})
+  }
+  
+  return t
+end
+
+return ScoreAndGrade

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -238,7 +238,7 @@ function ScoreAndGrade.GetGradeActor(opts_in)
         if     fullComboType == 'TapNoteScore_W1' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.20)
         elseif fullComboType == 'TapNoteScore_W2' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
         elseif fullComboType == 'TapNoteScore_W3' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
-        elseif fullComboType == 'TapNoteScore_W4' then FullCombo:diffuse(GameColor.Judgment['TapNoteScore_W4']):stopeffect()
+        elseif fullComboType == 'TapNoteScore_W4' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W4']):stopeffect()
         else
           assert(false, 'Unknown Full Combo type: ' .. fullComboType)
         end

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -1,5 +1,9 @@
+if StarlightCache and StarlightCache.ScoreAndGrade then
+  return StarlightCache.ScoreAndGrade
+end
 
 local ScoreAndGrade = {}
+StarlightCache.ScoreAndGrade = ScoreAndGrade
 
 local DEBUG = false
 

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -89,13 +89,15 @@ function ScoreAndGrade.CreateScoreActor(opts)
   
   local SetScoreCommand = properties.SetScoreCommand
   properties.SetScoreCommand = function(self, params)
-    local stats = params.Stats
-    local steps = params.Steps
-  
     local score
-    if stats then
-      assert(steps)
-      score = ScoreAndGrade.GetScore(stats, steps, properties.ShowEXScore)
+    if params then
+      local stats = params.Stats
+      local steps = params.Steps
+    
+      if stats then
+        assert(steps)
+        score = ScoreAndGrade.GetScore(stats, steps, properties.ShowEXScore)
+      end
     end
     
     self:settext(score and commify(score) or '0')
@@ -128,13 +130,15 @@ function ScoreAndGrade.CreateScoreRollingActor(opts)
   
   local SetScoreCommand = properties.SetScoreCommand
   properties.SetScoreCommand = function(self, params)
-    local stats = params.Stats
-    local steps = params.Steps
-    
     local score
-    if stats then
-      assert(steps)
-      score = ScoreAndGrade.GetScore(stats, steps, properties.ShowEXScore)
+    if params then
+      local stats = params.Stats
+      local steps = params.Steps
+      
+      if stats then
+        assert(steps)
+        score = ScoreAndGrade.GetScore(stats, steps, properties.ShowEXScore)
+      end
     end
     self:targetnumber(score and score or 0)
     
@@ -212,14 +216,18 @@ function ScoreAndGrade.CreateGradeActor(opts)
   
   local SetScoreCommand = properties.SetScoreCommand
   properties.SetScoreCommand = function(self, params)
-    local stats = params.Stats
-    local steps = params.Steps
-    
     local grade
-    if stats then
-      assert(steps)
-      grade = ScoreAndGrade.GetGrade(stats, steps)
+    local stats
+    if params then
+      stats = params.Stats
+      local steps = params.Steps
+      
+      if stats then
+        assert(steps)
+        grade = ScoreAndGrade.GetGrade(stats, steps)
+      end
     end
+    
     self:visible(not not grade)
     
     if grade then

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -1,11 +1,12 @@
-if StarlightCache and StarlightCache.ScoreAndGrade then
+local DEBUG = false
+
+if StarlightCache and StarlightCache.ScoreAndGrade and not DEBUG then
   return StarlightCache.ScoreAndGrade
 end
 
 local ScoreAndGrade = {}
 StarlightCache.ScoreAndGrade = ScoreAndGrade
 
-local DEBUG = false
 
 -- Should we maybe have this in SN2Scoring instead?
 local defaultTierToSN2TierTable = {
@@ -157,7 +158,7 @@ end
 function ScoreAndGrade.CreateGradeActor(opts)
   local properties = {
     Big = false,
-    AlternativeFC = false,  -- Only effective if Big = false
+    AlternativeFC = false,  -- Only effective if Big == false
     ActorConcat = nil,      -- Used to apply special OnCommand/OffCommand
   }
   if opts then
@@ -203,17 +204,30 @@ function ScoreAndGrade.CreateGradeActor(opts)
         }
       }
 		}
-  else
+  elseif properties.AlternativeFC then
     properties[#properties+1] = Def.Sprite{
       Name='FullCombo',
-      InitCommand = function(self)
+      Texture=THEME:GetPathG('Player', 'Badge FullCombo'),
+      InitCommand=function(self)
         self:visible(false)
-        if properties.AlternativeFC then 
-          self:xy(18,4):Load(THEME:GetPathG('Player','Badge FullCombo')):zoom(0.5):shadowlength(1)
-        else
-          self:xy(14,5):Load(THEME:GetPathG('','myMusicWheel/star.png')):zoom(0.4)
-        end
+        self:xy(18,4):zoom(0.5):shadowlength(1)
       end,
+    }
+  else
+    properties[#properties+1] = Def.ActorFrame{
+      Name='FullCombo',
+      InitCommand=function(self)
+        self:visible(false)
+        self:xy(14,5):zoom(0.4)
+      end,
+      Def.Sprite{
+        Name='Star',
+        Texture=THEME:GetPathG('','myMusicWheel/star.png'),
+      },
+      Def.Sprite{
+        Name='ColorStar',
+        Texture=THEME:GetPathG('','myMusicWheel/colorstar.png'),
+      }
     }
   end
   
@@ -256,10 +270,16 @@ function ScoreAndGrade.CreateGradeActor(opts)
             assert(false, 'Unknown Full Combo type: ' .. fullComboType)
           end
         else
-          if     fullComboType == 'TapNoteScore_W1' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.20)
-          elseif fullComboType == 'TapNoteScore_W2' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
-          elseif fullComboType == 'TapNoteScore_W3' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
-          elseif fullComboType == 'TapNoteScore_W4' then FullCombo:diffuse(GameColor.Judgment['JudgmentLine_W4']):stopeffect()
+          local FCRing
+          if properties.AlternativeFC then
+            FCRing = FullCombo
+          else
+            FCRing = FullCombo:GetChild('ColorStar')
+          end
+          if     fullComboType == 'TapNoteScore_W1' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.2)
+          elseif fullComboType == 'TapNoteScore_W2' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
+          elseif fullComboType == 'TapNoteScore_W3' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
+          elseif fullComboType == 'TapNoteScore_W4' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W4']):stopeffect()
           else
             assert(false, 'Unknown Full Combo type: ' .. fullComboType)
           end

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -189,8 +189,8 @@ end
 function ScoreAndGrade.CreateGradeActor(opts)
   local properties = {
     Big = false,
+    HideFC = false,
     AlternativeFC = false,  -- Only effective if Big == false
-    ActorConcat = nil,      -- Used to apply special OnCommand/OffCommand
   }
   if opts then
     for k, v in pairs(opts) do properties[k] = v end
@@ -200,66 +200,67 @@ function ScoreAndGrade.CreateGradeActor(opts)
     Name='Grade',
   }
   
-  local FullCombo
-  if properties.Big then 
-    properties[#properties+1] = Def.ActorFrame{
-      Name='FullCombo',
-      InitCommand=function(self)
-        self:visible(false)
-        self:xy(190, 30)
-      end,
-      Def.ActorFrame{
-        Name='Star1',
+  if not properties.HideFC then
+    if properties.Big then 
+      properties[#properties+1] = Def.ActorFrame{
+        Name='FullCombo',
         InitCommand=function(self)
-          self:spin():effectmagnitude(0,0,-170)
+          self:visible(false)
+          self:xy(190, 30)
+        end,
+        Def.ActorFrame{
+          Name='Star1',
+          InitCommand=function(self)
+            self:spin():effectmagnitude(0,0,-170)
+          end,
+          Def.Sprite{
+            Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/star.png'),
+          },
+          Def.Sprite{
+            Name='ColorStar',
+            Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/colorstar.png'),
+          }
+        };
+        Def.ActorFrame{
+          Name='Star2',
+          InitCommand=function(self)
+            self:spin():effectmagnitude(0,0,80):diffusealpha(0.5)
+          end,
+          Def.Sprite{
+            Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/star.png'),
+          },
+          Def.Sprite{
+            Name='ColorStar',
+            Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/colorstar.png'),
+          }
+        }
+      }
+    elseif properties.AlternativeFC then
+      properties[#properties+1] = Def.Sprite{
+        Name='FullCombo',
+        Texture=THEME:GetPathG('Player', 'Badge FullCombo'),
+        InitCommand=function(self)
+          self:visible(false)
+          self:xy(18,4):zoom(0.5):shadowlength(1)
+        end,
+      }
+    else
+      properties[#properties+1] = Def.ActorFrame{
+        Name='FullCombo',
+        InitCommand=function(self)
+          self:visible(false)
+          self:xy(14,5):zoom(0.4)
         end,
         Def.Sprite{
-          Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/star.png'),
+          Name='Star',
+          Texture=THEME:GetPathG('','myMusicWheel/star.png'),
         },
         Def.Sprite{
           Name='ColorStar',
-          Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/colorstar.png'),
-        }
-      };
-      Def.ActorFrame{
-        Name='Star2',
-        InitCommand=function(self)
-          self:spin():effectmagnitude(0,0,80):diffusealpha(0.5)
-        end,
-        Def.Sprite{
-          Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/star.png'),
-        },
-        Def.Sprite{
-          Name='ColorStar',
-          Texture=THEME:GetPathB('ScreenEvaluationNormal','decorations/grade/colorstar.png'),
+          Texture=THEME:GetPathG('','myMusicWheel/colorstar.png'),
         }
       }
-		}
-  elseif properties.AlternativeFC then
-    properties[#properties+1] = Def.Sprite{
-      Name='FullCombo',
-      Texture=THEME:GetPathG('Player', 'Badge FullCombo'),
-      InitCommand=function(self)
-        self:visible(false)
-        self:xy(18,4):zoom(0.5):shadowlength(1)
-      end,
-    }
-  else
-    properties[#properties+1] = Def.ActorFrame{
-      Name='FullCombo',
-      InitCommand=function(self)
-        self:visible(false)
-        self:xy(14,5):zoom(0.4)
-      end,
-      Def.Sprite{
-        Name='Star',
-        Texture=THEME:GetPathG('','myMusicWheel/star.png'),
-      },
-      Def.Sprite{
-        Name='ColorStar',
-        Texture=THEME:GetPathG('','myMusicWheel/colorstar.png'),
-      }
-    }
+    end
   end
   
   local SetScoreCommand = properties.SetScoreCommand
@@ -280,8 +281,6 @@ function ScoreAndGrade.CreateGradeActor(opts)
     
     if grade then
       local Grade = self:GetChild('Grade')
-      local FullCombo = self:GetChild('FullCombo')
-      local fullComboType = ScoreAndGrade.GetFullComboType(stats)
       
       if properties.Big then
         Grade:Load(THEME:GetPathB('ScreenEvaluationNormal decorations/grade/GradeDisplayEval', ToEnumShortString(grade)))
@@ -289,30 +288,34 @@ function ScoreAndGrade.CreateGradeActor(opts)
         Grade:Load(THEME:GetPathG('myMusicWheel/GradeDisplayEval', ToEnumShortString(grade)))
       end
       
-      FullCombo:visible(not not fullComboType)
-      
-      if fullComboType then
-        if properties.Big then
-          local ringColor = FullComboEffectColor[fullComboType]
-          if ringColor then  
-            FullCombo:GetChild('Star1'):GetChild('ColorStar'):diffuse(ringColor)
-            FullCombo:GetChild('Star2'):GetChild('ColorStar'):diffuse(ringColor)
+      if not properties.HideFC then
+        local FullCombo = self:GetChild('FullCombo')
+        local fullComboType = ScoreAndGrade.GetFullComboType(stats)
+        FullCombo:visible(not not fullComboType)
+        
+        if fullComboType then
+          if properties.Big then
+            local ringColor = FullComboEffectColor[fullComboType]
+            if ringColor then  
+              FullCombo:GetChild('Star1'):GetChild('ColorStar'):diffuse(ringColor)
+              FullCombo:GetChild('Star2'):GetChild('ColorStar'):diffuse(ringColor)
+            else
+              assert(false, 'Unknown Full Combo type: ' .. fullComboType)
+            end
           else
-            assert(false, 'Unknown Full Combo type: ' .. fullComboType)
-          end
-        else
-          local FCRing
-          if properties.AlternativeFC then
-            FCRing = FullCombo
-          else
-            FCRing = FullCombo:GetChild('ColorStar')
-          end
-          if     fullComboType == 'TapNoteScore_W1' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.2)
-          elseif fullComboType == 'TapNoteScore_W2' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
-          elseif fullComboType == 'TapNoteScore_W3' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
-          elseif fullComboType == 'TapNoteScore_W4' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W4']):stopeffect()
-          else
-            assert(false, 'Unknown Full Combo type: ' .. fullComboType)
+            local FCRing
+            if properties.AlternativeFC then
+              FCRing = FullCombo
+            else
+              FCRing = FullCombo:GetChild('ColorStar')
+            end
+            if     fullComboType == 'TapNoteScore_W1' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W1']):glowblink():effectperiod(0.2)
+            elseif fullComboType == 'TapNoteScore_W2' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W2']):glowshift()
+            elseif fullComboType == 'TapNoteScore_W3' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W3']):stopeffect()
+            elseif fullComboType == 'TapNoteScore_W4' then FCRing:diffuse(GameColor.Judgment['JudgmentLine_W4']):stopeffect()
+            else
+              assert(false, 'Unknown Full Combo type: ' .. fullComboType)
+            end
           end
         end
       end

--- a/Modules/ScoreAndGrade.lua
+++ b/Modules/ScoreAndGrade.lua
@@ -172,10 +172,9 @@ function ScoreAndGrade.CreateGradeActor(opts)
   if properties.Big then 
     properties[#properties+1] = Def.ActorFrame{
       Name='FullCombo',
-      FOV=120,
       InitCommand=function(self)
         self:visible(false)
-        self:xy(190, 30):bob():effectmagnitude(0,0,20)
+        self:xy(190, 30)
       end,
       Def.ActorFrame{
         Name='Star1',

--- a/Scripts/99 Scoring.lua
+++ b/Scripts/99 Scoring.lua
@@ -33,7 +33,14 @@ local maxHoldValues =
 --argument and return the number of TNSes or HNSes there are in that thing,
 --pack that information into something useful.
 --This is a pretty bad function description, so just see how it's used.
-local function GetScoreDataFromThing(thing, tnsFuncName, hnsFuncName)
+local function GetScoreDataFromThing(thing)
+    local tnsFuncName, hnsFuncName
+    if     lua.CheckType('HighScore',        thing) then tnsFuncName, hnsFuncName = 'GetTapNoteScore',  'GetHoldNoteScore'
+    elseif lua.CheckType('PlayerStageStats', thing) then tnsFuncName, hnsFuncName = 'GetTapNoteScores', 'GetHoldNoteScores'
+    else
+        error('First argument is not HighScore or PlayerStageStats')
+    end
+    
     local output = {}
     --how class function lookup works internally in Lua
     local hnsFunc = thing[hnsFuncName]
@@ -54,8 +61,8 @@ local function GetScoreDataFromThing(thing, tnsFuncName, hnsFuncName)
     return output
 end
 
-function SN2Scoring.GetCurrentScoreData(pss, judgment)
-    local scoreData = GetScoreDataFromThing(pss, "GetTapNoteScores", "GetHoldNoteScores")
+function SN2Scoring.GetCurrentScoreData(HSorPSS, judgment)    
+    local scoreData = GetScoreDataFromThing(HSorPSS)
     --workaround for the fact that the current TNS or HNS won't have been
     --added to the PSS yet.
     if judgment and scoreData[judgment] then
@@ -148,9 +155,8 @@ function SN2Scoring.ComputeEXScoreFromData(data,max)
     return totalScore * finalMultiplier
 end
 
-function SN2Scoring.GetSN2ScoreFromHighScore(steps, highScore)
-    local scoreData = GetScoreDataFromThing(highScore, "GetTapNoteScore",
-        "GetHoldNoteScore")
+function SN2Scoring.GetSN2ScoreFromHighScore(steps, HSorPSS)
+    local scoreData = GetScoreDataFromThing(HSorPSS)
     local radar = steps:GetRadarValues(pn)
     scoreData.Total = radar:GetValue('RadarCategory_TapsAndHolds')+
         radar:GetValue('RadarCategory_Holds')+radar:GetValue('RadarCategory_Rolls')


### PR DESCRIPTION
This patch is a large refactor of the score and grade displays to fix numerous bugs and inconsistencies with them. It fixes them by unifying them all to use the new `ScoreAndGrade` module, which is responsible for calculating and displaying the correct score and grade. This means the calculations and logic is now under a central module that ensures consistency and makes it easier to adjust the behavior globally. Due to the nature of this refactor this also optimizes the code a bit.

A very noteable change with this bugfix is that we now don't do `PlayerStageStats:SetScore(...)` and `PlayerStageStats:SetCurMaxScore(...)` anymore, which means the game will now save the default Stepmania score and grade calculations into `Stats.xml` instead of the theme-specific (DDR A score) calculations it did in the past. This increases compatibility with other themes if the player were to switch between multiple themes. The scores and grades are now converted within the `ScoreAndGrade` module before being displayed.

If you used this theme before this bugfix and have the "Convert Scores/Grades" theme option Off, you'll then notice that new scores are shown to be 10 times greater: with old scores having a 10-million range (DDR A scoring), and new scores having a 100-million range (SM5 scoring). That is expected behavior because it's now showing SM5's default scoring system and we aren't replacing it using `PlayerStageStats:SetScore(...)` anymore. To fix this scoring inconsistency you'll either need to delete your old scores or turn On the "Convert Scores/Grades" theme option. The "Convert Scores/Grades" option makes all scores and grades to be shown using the DDR A scoring system regardless of what's saved in `Stats.xml`.

In other words, this bugfix lets the game use the default SM5's scoring system under the hood and only converts it to a DDR A score for display only (if the "Convert Scores/Grades" option is On).

Fixes bugs such as #30 and #51